### PR TITLE
✨ 주변 장소 뷰에서 동적 스크롤 기능과 이미지를 추가했습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E467661290272C100556C41 /* NearbyPlaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E467660290272C100556C41 /* NearbyPlaceView.swift */; };
 		0EFB5BA328FF08A100174291 /* NearbyPlaceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFB5BA228FF08A100174291 /* NearbyPlaceViewController.swift */; };
 		0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFB5BA42900E9D800174291 /* IntroduceView.swift */; };
 		0EFB5BCB29017FBB00174291 /* TempGalleryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EFB5BCA29017FBB00174291 /* TempGalleryView.swift */; };
@@ -45,6 +46,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E467660290272C100556C41 /* NearbyPlaceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyPlaceView.swift; sourceTree = "<group>"; };
 		0EFB5BA228FF08A100174291 /* NearbyPlaceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyPlaceViewController.swift; sourceTree = "<group>"; };
 		0EFB5BA42900E9D800174291 /* IntroduceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntroduceView.swift; sourceTree = "<group>"; };
 		0EFB5BCA29017FBB00174291 /* TempGalleryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempGalleryView.swift; sourceTree = "<group>"; };
@@ -102,11 +104,12 @@
 			isa = PBXGroup;
 			children = (
 				0EFB5BA228FF08A100174291 /* NearbyPlaceViewController.swift */,
+				0E467660290272C100556C41 /* NearbyPlaceView.swift */,
 				0EFB5BCA29017FBB00174291 /* TempGalleryView.swift */,
 				0EFB5BA42900E9D800174291 /* IntroduceView.swift */,
 			);
 			path = NearbyPlace;
-      sourceTree = "<group>";
+			sourceTree = "<group>";
 		};
 		16083B4729013F9A008056D4 /* CheckList */ = {
 			isa = PBXGroup;
@@ -410,6 +413,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5FDC17BF28FE799C0060DBB7 /* ViewController.swift in Sources */,
+				0E467661290272C100556C41 /* NearbyPlaceView.swift in Sources */,
 				0EFB5BCB29017FBB00174291 /* TempGalleryView.swift in Sources */,
 				0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */,
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,

--- a/Workade/Assets.xcassets/officeImage_test.imageset/Contents.json
+++ b/Workade/Assets.xcassets/officeImage_test.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "officeImage_test.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Workade/SceneDelegate.swift
+++ b/Workade/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())
+        window?.rootViewController = NearbyPlaceViewController()
         window?.makeKeyAndVisible()
     }
 

--- a/Workade/SceneDelegate.swift
+++ b/Workade/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(frame: windowScene.coordinateSpace.bounds)
         window?.windowScene = windowScene
-        window?.rootViewController = NearbyPlaceViewController()
+        window?.rootViewController = UINavigationController(rootViewController: HomeViewController())
         window?.makeKeyAndVisible()
     }
 

--- a/Workade/Views&ViewModels/CheckList/CheckListCell/CheckListCell.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListCell/CheckListCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SwiftUI
 
 class CheckListCell: UICollectionViewCell {
-    static let identifier = "CheckListCell"
+//    static let identifier = "CheckListCell"
     
     var uncheckCount: Int = 0
     var checkCount: Int = 0

--- a/Workade/Views&ViewModels/NearbyPlace/IntroduceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/IntroduceView.swift
@@ -10,7 +10,9 @@ import UIKit
 class IntroduceView: UIView {
     private let testLabel: UILabel = {
         let label = UILabel()
-        label.text = "소개 뷰"
+        label.text = "Lorem Ipsum is simply dummy"
+        label.lineBreakMode = .byWordWrapping
+        label.numberOfLines = 0
         label.textAlignment = .center
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -30,11 +32,13 @@ class IntroduceView: UIView {
     
     private func setupLayout() {
         addSubview(testLabel)
+        
         NSLayoutConstraint.activate([
             testLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             testLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             testLabel.topAnchor.constraint(equalTo: topAnchor),
-            testLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+            testLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            testLabel.heightAnchor.constraint(equalToConstant: 500)
         ])
     }
 }

--- a/Workade/Views&ViewModels/NearbyPlace/IntroduceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/IntroduceView.swift
@@ -10,7 +10,7 @@ import UIKit
 class IntroduceView: UIView {
     private let testLabel: UILabel = {
         let label = UILabel()
-        label.text = "Lorem Ipsum is simply dummy"
+        label.text = "소개 뷰"
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         label.textAlignment = .center

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -89,6 +89,13 @@ class NearbyPlaceView: UIView {
     }
     
     private func setupLayout() {
+        removeSegmentDefaultEffect()
+        
+        setupScrollViewLayout()
+        setupNearbyPlaceDetailLayout()
+    }
+    
+    private func setupScrollViewLayout() {
         // 스크롤 뷰 추가
         addSubview(scrollView)
         let scrollViewGuide = scrollView.contentLayoutGuide
@@ -100,8 +107,6 @@ class NearbyPlaceView: UIView {
         contentsContainer.addSubview(segmentUnderLine)
         contentsContainer.addSubview(introduceView)
         contentsContainer.addSubview(galleryView)
-        
-        removeSegmentDefaultEffect()
         
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: topAnchor),
@@ -117,7 +122,9 @@ class NearbyPlaceView: UIView {
             contentsContainer.trailingAnchor.constraint(equalTo: scrollViewGuide.trailingAnchor),
             contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
         ])
-        
+    }
+    
+    private func setupNearbyPlaceDetailLayout() {
         NSLayoutConstraint.activate([
             placeImageView.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
             placeImageView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -13,10 +13,8 @@ class NearbyPlaceView: UIView {
     
     let scrollView: UIScrollView = {
         let scrollView = UIScrollView()
-        // contentInsetAdjustmentBehavior -> safeArea를 ignore
-        scrollView.contentInsetAdjustmentBehavior = .never
         scrollView.translatesAutoresizingMaskIntoConstraints = false
-
+        
         return scrollView
     }()
     
@@ -27,15 +25,25 @@ class NearbyPlaceView: UIView {
         return contentsContainer
     }()
     
+    private let placeImageContainer: UIView = {
+        let placeImageContainer = UIView()
+        placeImageContainer.translatesAutoresizingMaskIntoConstraints = false
+        
+        return placeImageContainer
+    }()
+    
     private let placeImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = UIColor.gray
+        imageView.image = UIImage(named: "OpieceTamna")
+        imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
     }()
     
+    // TODO: 치콩이 통합으로 쓸 수 있는 환경을 구축해 놓았습니다. 머지 이후 통합시키겠습니다.
     private lazy var segmentedControl: UISegmentedControl = {
         let segmentedControl = UISegmentedControl(items: ["소개", "갤러리"])
         segmentedControl.setTitleTextAttributes([
@@ -78,8 +86,11 @@ class NearbyPlaceView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        
+        // 스크롤 뷰의 영역을 컨텐츠 크기에 따라 dynamic하게 변경하기 위한 설정
         introduceBottomConstraints = introduceView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -20)
         galleryBottomConstraints = galleryView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -20)
+        
         setupLayout()
     }
     
@@ -100,60 +111,62 @@ class NearbyPlaceView: UIView {
         let scrollViewGuide = scrollView.contentLayoutGuide
         scrollView.addSubview(contentsContainer)
         
-        // 스크롤 뷰에 들어갈 애들
+        // 스크롤 뷰에 들어갈 컴포넌트들
+        contentsContainer.addSubview(placeImageContainer)
         contentsContainer.addSubview(placeImageView)
         contentsContainer.addSubview(segmentedControl)
         contentsContainer.addSubview(segmentUnderLine)
         contentsContainer.addSubview(introduceView)
         contentsContainer.addSubview(galleryView)
         
+        // priority 설정을 통해,
+        let placeImageViewTopConstraint = placeImageView.topAnchor.constraint(equalTo: topAnchor)
+        // layout이 깨지는 것을 방지하기 위한 우선순위 설정
+        placeImageViewTopConstraint.priority = .defaultHigh
+
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        ])
-        
-        NSLayoutConstraint.activate([
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            
             contentsContainer.topAnchor.constraint(equalTo: scrollViewGuide.topAnchor),
             contentsContainer.bottomAnchor.constraint(equalTo: scrollViewGuide.bottomAnchor),
             contentsContainer.leadingAnchor.constraint(equalTo: scrollViewGuide.leadingAnchor),
             contentsContainer.trailingAnchor.constraint(equalTo: scrollViewGuide.trailingAnchor),
-            contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+            contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            
+            placeImageContainer.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
+            placeImageContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
+            placeImageContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
+            placeImageContainer.heightAnchor.constraint(equalToConstant: 420),
+            
+            placeImageViewTopConstraint,
+            placeImageView.bottomAnchor.constraint(equalTo: placeImageContainer.bottomAnchor),
+            placeImageView.leadingAnchor.constraint(equalTo: placeImageContainer.leadingAnchor),
+            placeImageView.trailingAnchor.constraint(equalTo: placeImageContainer.trailingAnchor),
+            // heightAnchor 설정을 통해, 세로가 긴 이미지가 들어올때 이미지 영역 깨지는걸 방지.
+            placeImageView.heightAnchor.constraint(greaterThanOrEqualTo: placeImageContainer.heightAnchor)
         ])
     }
     
     private func setupNearbyPlaceDetailLayout() {
         NSLayoutConstraint.activate([
-            placeImageView.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
-            placeImageView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),
-            placeImageView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor),
-            placeImageView.heightAnchor.constraint(equalToConstant: 420),
-            placeImageView.widthAnchor.constraint(equalTo: contentsContainer.widthAnchor)
-        ])
-        
-        NSLayoutConstraint.activate([
-            segmentedControl.topAnchor.constraint(equalTo: placeImageView.bottomAnchor),
+            segmentedControl.topAnchor.constraint(equalTo: placeImageContainer.bottomAnchor),
             segmentedControl.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             segmentedControl.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
-            segmentedControl.heightAnchor.constraint(equalToConstant: 50)
-        ])
-        
-        NSLayoutConstraint.activate([
+            segmentedControl.heightAnchor.constraint(equalToConstant: 50),
+            
             segmentUnderLine.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor),
             segmentUnderLine.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),
             segmentUnderLine.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor),
-            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2)
-        ])
-        
-        NSLayoutConstraint.activate([
+            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2),
+            
             introduceView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
             introduceView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             introduceView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
-            introduceBottomConstraints
-        ])
-        
-        NSLayoutConstraint.activate([
+            introduceBottomConstraints,
+            
             galleryView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
             galleryView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             galleryView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20)
@@ -178,6 +191,7 @@ class NearbyPlaceView: UIView {
         }
     }
     
+    // TODO: 머지 이후 치콩이 작성한 뷰와 합치며 삭제될 함수입니다.
     private func removeSegmentDefaultEffect() {
         let image = UIImage()
         segmentedControl.setBackgroundImage(image, for: .normal, barMetrics: .default)

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -35,7 +35,7 @@ class NearbyPlaceView: UIView {
     private let placeImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.backgroundColor = UIColor.gray
-        imageView.image = UIImage(named: "OpieceTamna")
+        imageView.image = UIImage(named: "officeImage_test")
         imageView.clipsToBounds = true
         imageView.contentMode = .scaleAspectFill
         imageView.translatesAutoresizingMaskIntoConstraints = false

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -106,41 +106,40 @@ class NearbyPlaceView: UIView {
     }
     
     private func setupScrollViewLayout() {
-        // 스크롤 뷰 추가
         addSubview(scrollView)
         let scrollViewGuide = scrollView.contentLayoutGuide
-        scrollView.addSubview(contentsContainer)
-        
-        // 스크롤 뷰에 들어갈 컴포넌트들
-        contentsContainer.addSubview(placeImageContainer)
-        contentsContainer.addSubview(placeImageView)
-        contentsContainer.addSubview(segmentedControl)
-        contentsContainer.addSubview(segmentUnderLine)
-        contentsContainer.addSubview(introduceView)
-        contentsContainer.addSubview(galleryView)
         
         // priority 설정을 통해,
         let placeImageViewTopConstraint = placeImageView.topAnchor.constraint(equalTo: topAnchor)
         // layout이 깨지는 것을 방지하기 위한 우선순위 설정
         placeImageViewTopConstraint.priority = .defaultHigh
-
+        
         NSLayoutConstraint.activate([
             scrollView.topAnchor.constraint(equalTo: topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
             scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        
+        scrollView.addSubview(contentsContainer)
+        NSLayoutConstraint.activate([
             contentsContainer.topAnchor.constraint(equalTo: scrollViewGuide.topAnchor),
             contentsContainer.bottomAnchor.constraint(equalTo: scrollViewGuide.bottomAnchor),
             contentsContainer.leadingAnchor.constraint(equalTo: scrollViewGuide.leadingAnchor),
             contentsContainer.trailingAnchor.constraint(equalTo: scrollViewGuide.trailingAnchor),
-            contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-            
+            contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+        
+        contentsContainer.addSubview(placeImageContainer)
+        NSLayoutConstraint.activate([
             placeImageContainer.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
             placeImageContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             placeImageContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
-            placeImageContainer.heightAnchor.constraint(equalToConstant: 420),
-            
+            placeImageContainer.heightAnchor.constraint(equalToConstant: 420)
+        ])
+        
+        contentsContainer.addSubview(placeImageView)
+        NSLayoutConstraint.activate([
             placeImageViewTopConstraint,
             placeImageView.bottomAnchor.constraint(equalTo: placeImageContainer.bottomAnchor),
             placeImageView.leadingAnchor.constraint(equalTo: placeImageContainer.leadingAnchor),
@@ -151,22 +150,32 @@ class NearbyPlaceView: UIView {
     }
     
     private func setupNearbyPlaceDetailLayout() {
+        contentsContainer.addSubview(segmentedControl)
         NSLayoutConstraint.activate([
             segmentedControl.topAnchor.constraint(equalTo: placeImageContainer.bottomAnchor),
             segmentedControl.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             segmentedControl.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
-            segmentedControl.heightAnchor.constraint(equalToConstant: 50),
-            
+            segmentedControl.heightAnchor.constraint(equalToConstant: 50)
+        ])
+        
+        contentsContainer.addSubview(segmentUnderLine)
+        NSLayoutConstraint.activate([
             segmentUnderLine.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor),
             segmentUnderLine.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),
             segmentUnderLine.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor),
-            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2),
-            
+            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2)
+        ])
+        
+        contentsContainer.addSubview(introduceView)
+        NSLayoutConstraint.activate([
             introduceView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
             introduceView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             introduceView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
-            introduceBottomConstraints,
-            
+            introduceBottomConstraints
+        ])
+        
+        contentsContainer.addSubview(galleryView)
+        NSLayoutConstraint.activate([
             galleryView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
             galleryView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
             galleryView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20)

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -29,7 +29,6 @@ class NearbyPlaceView: UIView {
     
     private let placeImageView: UIImageView = {
         let imageView = UIImageView()
-        // TODO: 임시 배경입니다. 스크롤 시 이미지 애니메이션 효과 적용하며 변경할 예정입니다.
         imageView.backgroundColor = UIColor.gray
         imageView.contentMode = .scaleAspectFill
         imageView.translatesAutoresizingMaskIntoConstraints = false

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -1,0 +1,186 @@
+//
+//  NearbyPlaceView.swift
+//  Workade
+//
+//  Created by ryu hyunsun on 2022/10/21.
+//
+
+import UIKit
+
+class NearbyPlaceView: UIView {
+    private var introduceBottomConstraints: NSLayoutConstraint!
+    private var galleryBottomConstraints: NSLayoutConstraint!
+    
+    let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        // contentInsetAdjustmentBehavior -> safeArea를 ignore
+        scrollView.contentInsetAdjustmentBehavior = .never
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        return scrollView
+    }()
+    
+    private let contentsContainer: UIView = {
+        let contentsContainer = UIView()
+        contentsContainer.translatesAutoresizingMaskIntoConstraints = false
+        
+        return contentsContainer
+    }()
+    
+    private let placeImageView: UIImageView = {
+        let imageView = UIImageView()
+        // TODO: 임시 배경입니다. 스크롤 시 이미지 애니메이션 효과 적용하며 변경할 예정입니다.
+        imageView.backgroundColor = UIColor.gray
+        imageView.contentMode = .scaleAspectFill
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    
+    private lazy var segmentedControl: UISegmentedControl = {
+        let segmentedControl = UISegmentedControl(items: ["소개", "갤러리"])
+        segmentedControl.setTitleTextAttributes([
+            NSAttributedString.Key.foregroundColor: UIColor.rgb(0xD1D1D6),
+            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
+                                                for: .normal)
+        segmentedControl.setTitleTextAttributes([
+            NSAttributedString.Key.foregroundColor: UIColor.theme.primary,
+            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
+                                                for: .selected)
+        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.addTarget(self, action: #selector(indexChanged(_:)), for: .valueChanged)
+        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        
+        return segmentedControl
+    }()
+    
+    private let segmentUnderLine: UIView = {
+        let segmentUnderLine = UIView()
+        segmentUnderLine.backgroundColor = UIColor.rgb(0xF2F2F7)
+        segmentUnderLine.translatesAutoresizingMaskIntoConstraints = false
+        
+        return segmentUnderLine
+    }()
+    
+    private let introduceView: IntroduceView = {
+        let view = IntroduceView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let galleryView: TempGalleryView = {
+        let view = TempGalleryView()
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        introduceBottomConstraints = introduceView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -20)
+        galleryBottomConstraints = galleryView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -20)
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    private func setupLayout() {
+        // 스크롤 뷰 추가
+        addSubview(scrollView)
+        let scrollViewGuide = scrollView.contentLayoutGuide
+        scrollView.addSubview(contentsContainer)
+        
+        // 스크롤 뷰에 들어갈 애들
+        contentsContainer.addSubview(placeImageView)
+        contentsContainer.addSubview(segmentedControl)
+        contentsContainer.addSubview(segmentUnderLine)
+        contentsContainer.addSubview(introduceView)
+        contentsContainer.addSubview(galleryView)
+        
+        removeSegmentDefaultEffect()
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            contentsContainer.topAnchor.constraint(equalTo: scrollViewGuide.topAnchor),
+            contentsContainer.bottomAnchor.constraint(equalTo: scrollViewGuide.bottomAnchor),
+            contentsContainer.leadingAnchor.constraint(equalTo: scrollViewGuide.leadingAnchor),
+            contentsContainer.trailingAnchor.constraint(equalTo: scrollViewGuide.trailingAnchor),
+            contentsContainer.widthAnchor.constraint(equalTo: scrollView.widthAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            placeImageView.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
+            placeImageView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),
+            placeImageView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor),
+            placeImageView.heightAnchor.constraint(equalToConstant: 420),
+            placeImageView.widthAnchor.constraint(equalTo: contentsContainer.widthAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            segmentedControl.topAnchor.constraint(equalTo: placeImageView.bottomAnchor),
+            segmentedControl.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
+            segmentedControl.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
+            segmentedControl.heightAnchor.constraint(equalToConstant: 50)
+        ])
+        
+        NSLayoutConstraint.activate([
+            segmentUnderLine.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor),
+            segmentUnderLine.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor),
+            segmentUnderLine.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor),
+            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2)
+        ])
+        
+        NSLayoutConstraint.activate([
+            introduceView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
+            introduceView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
+            introduceView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20),
+            introduceBottomConstraints
+        ])
+        
+        NSLayoutConstraint.activate([
+            galleryView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 20),
+            galleryView.leadingAnchor.constraint(equalTo: contentsContainer.leadingAnchor, constant: 20),
+            galleryView.trailingAnchor.constraint(equalTo: contentsContainer.trailingAnchor, constant: -20)
+        ])
+    }
+    
+    @objc
+    private func indexChanged(_ segmentedControl: UISegmentedControl) {
+        switch segmentedControl.selectedSegmentIndex {
+        case 0:
+            introduceView.isHidden = false
+            galleryView.isHidden = true
+            galleryBottomConstraints.isActive = false
+            introduceBottomConstraints.isActive = true
+        case 1:
+            introduceView.isHidden = true
+            galleryView.isHidden = false
+            introduceBottomConstraints.isActive = false
+            galleryBottomConstraints.isActive = true
+        default:
+            break
+        }
+    }
+    
+    private func removeSegmentDefaultEffect() {
+        let image = UIImage()
+        segmentedControl.setBackgroundImage(image, for: .normal, barMetrics: .default)
+        segmentedControl.setBackgroundImage(image, for: .selected, barMetrics: .default)
+        segmentedControl.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
+        segmentedControl.setDividerImage(
+            image,
+            forLeftSegmentState: .selected,
+            rightSegmentState: .normal,
+            barMetrics: .default)
+    }
+}

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
@@ -10,14 +10,13 @@ import UIKit
 class NearbyPlaceViewController: UIViewController {
     private lazy var segmentedControl: UISegmentedControl = {
         let segmentedControl = UISegmentedControl(items: ["소개", "갤러리"])
-        // TODO: 폰트 컬러, 폰트 사이즈는 머지 이후 작업 하도록 하겠습니다.
         segmentedControl.setTitleTextAttributes([
-            NSAttributedString.Key.foregroundColor: UIColor.gray,
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .semibold)],
+            NSAttributedString.Key.foregroundColor: UIColor.rgb(0xD1D1D6),
+            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
                                                 for: .normal)
         segmentedControl.setTitleTextAttributes([
-            NSAttributedString.Key.foregroundColor: UIColor.black,
-            NSAttributedString.Key.font: UIFont.systemFont(ofSize: 17, weight: .semibold)],
+            NSAttributedString.Key.foregroundColor: UIColor.theme.primary,
+            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
                                                 for: .selected)
         segmentedControl.selectedSegmentIndex = 0
         segmentedControl.addTarget(self, action: #selector(indexChanged(_:)), for: .valueChanged)
@@ -43,7 +42,7 @@ class NearbyPlaceViewController: UIViewController {
     
     private let segmentUnderLine: UIView = {
         let segmentUnderLine = UIView()
-        segmentUnderLine.backgroundColor = .systemGray5
+        segmentUnderLine.backgroundColor = UIColor.rgb(0xF2F2F7)
         segmentUnderLine.translatesAutoresizingMaskIntoConstraints = false
         
         return segmentUnderLine

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
@@ -8,121 +8,15 @@
 import UIKit
 
 class NearbyPlaceViewController: UIViewController {
-    private lazy var segmentedControl: UISegmentedControl = {
-        let segmentedControl = UISegmentedControl(items: ["소개", "갤러리"])
-        segmentedControl.setTitleTextAttributes([
-            NSAttributedString.Key.foregroundColor: UIColor.rgb(0xD1D1D6),
-            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
-                                                for: .normal)
-        segmentedControl.setTitleTextAttributes([
-            NSAttributedString.Key.foregroundColor: UIColor.theme.primary,
-            NSAttributedString.Key.font: UIFont.customFont(for: .headline)],
-                                                for: .selected)
-        segmentedControl.selectedSegmentIndex = 0
-        segmentedControl.addTarget(self, action: #selector(indexChanged(_:)), for: .valueChanged)
-        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
-        
-        return segmentedControl
-    }()
-    
-    private let introduceView: IntroduceView = {
-        let view = IntroduceView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return view
-    }()
-    
-    private let galleryView: TempGalleryView = {
-        let view = TempGalleryView()
-        view.alpha = 0
-        view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return view
-    }()
-    
-    private let segmentUnderLine: UIView = {
-        let segmentUnderLine = UIView()
-        segmentUnderLine.backgroundColor = UIColor.rgb(0xF2F2F7)
-        segmentUnderLine.translatesAutoresizingMaskIntoConstraints = false
-        
-        return segmentUnderLine
-    }()
+    private let nearbyPlaceView = NearbyPlaceView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        setupLayout()
     }
     
-    // 레이아웃 설정.
-    private func setupLayout() {
-        view.addSubview(segmentedControl)
-        view.addSubview(segmentUnderLine)
-        view.addSubview(galleryView)
-        view.addSubview(introduceView)
-        
-        removeSegmentBackground()
-        removeSegmentDivider()
-        
-        NSLayoutConstraint.activate([
-            segmentedControl.topAnchor.constraint(equalTo: view.topAnchor, constant: 80),
-            segmentedControl.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            segmentedControl.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            segmentedControl.heightAnchor.constraint(equalToConstant: 50)
-        ])
-        
-        NSLayoutConstraint.activate([
-            segmentUnderLine.topAnchor.constraint(equalTo: segmentedControl.bottomAnchor),
-            segmentUnderLine.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            segmentUnderLine.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            segmentUnderLine.heightAnchor.constraint(equalToConstant: 2)
-        ])
-        
-        NSLayoutConstraint.activate([
-            introduceView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 10),
-            introduceView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            introduceView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            introduceView.heightAnchor.constraint(equalToConstant: 50)
-        ])
-        
-        NSLayoutConstraint.activate([
-            galleryView.topAnchor.constraint(equalTo: segmentUnderLine.bottomAnchor, constant: 10),
-            galleryView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            galleryView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            galleryView.heightAnchor.constraint(equalToConstant: 50)
-        ])
-    }
-    
-    // segmented controller 액션.
-    @objc
-    private func indexChanged(_ segmentedControl: UISegmentedControl) {
-        switch segmentedControl.selectedSegmentIndex {
-        case 0:
-            introduceView.alpha = 1
-            galleryView.alpha = 0
-            
-        case 1:
-            introduceView.alpha = 0
-            galleryView.alpha = 1
-            
-        default:
-            break
-        }
-    }
-    
-    private func removeSegmentBackground() {
-        let image = UIImage()
-        segmentedControl.setBackgroundImage(image, for: .normal, barMetrics: .default)
-        segmentedControl.setBackgroundImage(image, for: .selected, barMetrics: .default)
-        segmentedControl.setBackgroundImage(image, for: .highlighted, barMetrics: .default)
-    }
-    
-    private func removeSegmentDivider() {
-        let image = UIImage()
-        segmentedControl.setDividerImage(
-            image,
-            forLeftSegmentState: .selected,
-            rightSegmentState: .normal,
-            barMetrics: .default)
+    override func loadView() {
+        super.loadView()
+        view = nearbyPlaceView
     }
 }

--- a/Workade/Views&ViewModels/NearbyPlace/TempGalleryView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/TempGalleryView.swift
@@ -11,7 +11,7 @@ import UIKit
 class TempGalleryView: UIView {
     private let testLabel: UILabel = {
         let label = UILabel()
-        label.text = "Lorem Ipsum is simply dummy text of the printing and typesetting industry"
+        label.text = "임시 갤러리 뷰"
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 0
         label.textAlignment = .center

--- a/Workade/Views&ViewModels/NearbyPlace/TempGalleryView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/TempGalleryView.swift
@@ -11,7 +11,9 @@ import UIKit
 class TempGalleryView: UIView {
     private let testLabel: UILabel = {
         let label = UILabel()
-        label.text = "갤러리 뷰"
+        label.text = "Lorem Ipsum is simply dummy text of the printing and typesetting industry"
+        label.lineBreakMode = .byWordWrapping
+        label.numberOfLines = 0
         label.textAlignment = .center
         label.textColor = .black
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -35,7 +37,8 @@ class TempGalleryView: UIView {
             testLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
             testLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
             testLabel.topAnchor.constraint(equalTo: topAnchor),
-            testLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+            testLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
+            testLabel.heightAnchor.constraint(equalToConstant: 1000)
         ])
     }
 }


### PR DESCRIPTION
# 배경
- 주변 장소 뷰에서 컨텐츠 들의 크기에 따라 동적으로 스크롤이 가능해야 합니다.
- 주변 장소 뷰에서 해당 장소의 이미지가 들어가야하고, 스크롤시 형태가 변해야합니다.

# 작업 내용
- 컬러, 폰트 통합하였습니다.
- 기존에 ViewController에서 View를 그렸던 것을, NearbyPlaceView라는 UIView 파일을 따로 작성하여 ViewController에서는 loadView만 되도록 만들었습니다.
- 소개 탭과 갤러리 탭의 컨텐츠 사이즈에 따라 스크롤 영역이 다르게 만들었습니다. 컨텐츠 사이즈는 각각 임의로 height를 주었습니다.
- 이미지를 추가하였고, 가로나 세로 이미지 상관없이 UI가 깨지지 않도록 했습니다. 큰 사이즈의 이미지의 경우 스크롤 시 서서히 크기가 변하게 구현했습니다.

# 테스트 방법
- scene delegate에서 window?.rootViewController를 NearbyPlaceViewController로 변경후 진행합니다.

# 리뷰 노트
- setupLayout 함수가 길어져 Constraint 그리는 부분을 분리하였습니다. 각각 UIVIew로 구분하려 하였지만, ScrollView의 컨트롤이 힘들어  포기했습니다. View의 코드가 길어진 점 양해 부탁드리겠습니다.

# 스크린샷
- 소개 탭을 눌렀을때 최대 스크롤
<img width="150" alt="스크린샷 2022-10-23 오전 1 26 58" src="https://user-images.githubusercontent.com/75309495/197350646-dbf470f5-14af-4576-8932-37358dfed557.png">

- 갤러리 탭을 눌렀을때 최대 스크롤
<img width="150" alt="스크린샷 2022-10-23 오전 1 27 13" src="https://user-images.githubusercontent.com/75309495/197350739-977759df-0581-4cf2-956c-09e96ead98e6.png">

