### PR TITLE
:sparkles: MapViewController ViewModel 분리 및 Home과 연결했습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		5F5C074E28FE81DE0089DD4B /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5C074D28FE81DE0089DD4B /* HomeModel.swift */; };
 		5FBADE5029056811008CCC58 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBADE4F29056811008CCC58 /* MapViewController.swift */; };
 		5FD1F5D2290A6BCB00744CCC /* MapPinModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD1F5D1290A6BCB00744CCC /* MapPinModel.swift */; };
+		5FD22E8C290B13A4003CF909 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD22E8B290B13A4003CF909 /* MapViewModel.swift */; };
 		5FDC17BB28FE799C0060DBB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BA28FE799C0060DBB7 /* AppDelegate.swift */; };
 		5FDC17BD28FE799C0060DBB7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BC28FE799C0060DBB7 /* SceneDelegate.swift */; };
 		5FDC17BF28FE799C0060DBB7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BE28FE799C0060DBB7 /* ViewController.swift */; };
@@ -78,10 +79,7 @@
 		A33835242903C96C009882BF /* CellItemDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33835232903C96C009882BF /* CellItemDetailViewController.swift */; };
 		A33835282903E03A009882BF /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33835272903E03A009882BF /* UIButton+.swift */; };
 		A35559A828FED2B2001E4254 /* TapDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35559A728FED2B2001E4254 /* TapDetailViewController.swift */; };
-		A33835282903E03A009882BF /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33835272903E03A009882BF /* UIButton+.swift */; };
 		A35BD48228FE85B200D1FA7C /* MagazineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */; };
-		A35559A828FED2B2001E4254 /* TapDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35559A728FED2B2001E4254 /* TapDetailViewController.swift */; };A33835282903E03A009882BF /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = A33835272903E03A009882BF /* UIButton+.swift */; };
-    A35BD48228FE85B200D1FA7C /* MagazineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */; };
 		A374B8562902856B003C7390 /* TapDetailCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = A374B8552902856B003C7390 /* TapDetailCell.swift */; };
 		A393992629081628000E129A /* CustomNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A393992529081628000E129A /* CustomNavigationBar.swift */; };
 		A3947B2329013EE200DA4E0D /* CustomSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3947B2229013EE200DA4E0D /* CustomSegmentedControl.swift */; };
@@ -132,6 +130,7 @@
 		5F5C074D28FE81DE0089DD4B /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		5FBADE4F29056811008CCC58 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		5FD1F5D1290A6BCB00744CCC /* MapPinModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinModel.swift; sourceTree = "<group>"; };
+		5FD22E8B290B13A4003CF909 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		5FDC17B728FE799C0060DBB7 /* Workade.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Workade.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FDC17BA28FE799C0060DBB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5FDC17BC28FE799C0060DBB7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -166,7 +165,6 @@
 		A33835232903C96C009882BF /* CellItemDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellItemDetailViewController.swift; sourceTree = "<group>"; };
 		A33835272903E03A009882BF /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		A35559A728FED2B2001E4254 /* TapDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapDetailViewController.swift; sourceTree = "<group>"; };
-		A33835272903E03A009882BF /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineViewController.swift; sourceTree = "<group>"; };
 		A374B8552902856B003C7390 /* TapDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapDetailCell.swift; sourceTree = "<group>"; };
 		A393992529081628000E129A /* CustomNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomNavigationBar.swift; sourceTree = "<group>"; };
@@ -332,6 +330,7 @@
 			isa = PBXGroup;
 			children = (
 				5FBADE4F29056811008CCC58 /* MapViewController.swift */,
+				5FD22E8B290B13A4003CF909 /* MapViewModel.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -450,7 +449,7 @@
 			path = SettingViewController;
 			sourceTree = "<group>";
 		};
-    A35BD48028FE85A800D1FA7C /* Magazine */ = {
+		A35BD48028FE85A800D1FA7C /* Magazine */ = {
 			isa = PBXGroup;
 			children = (
 				A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */,
@@ -634,13 +633,13 @@
 				2154A8932909142E00486344 /* CheckListTemplateCell.swift in Sources */,
 				2120F56A290134D10035D36E /* GalleryCollectionViewCell.swift in Sources */,
 				96433239290A783100FBECAF /* Binder.swift in Sources */,
-				2120F5682901331B0035D36E /* GalleryViewController.swift in Sources */,
 				5FDC17BF28FE799C0060DBB7 /* ViewController.swift in Sources */,
 				0E467661290272C100556C41 /* NearbyPlaceView.swift in Sources */,
 				96433231290A746400FBECAF /* UIImageView+.swift in Sources */,
 				0E370E6529091B3A009C69BB /* DetailDataModel.swift in Sources */,
 				0EFB5BCB29017FBB00174291 /* GalleryView.swift in Sources */,
 				0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */,
+				5FD22E8C290B13A4003CF909 /* MapViewModel.swift in Sources */,
 				16CBD46A2902FB0F0056A641 /* UITableView+.swift in Sources */,
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,
 				2154A89B29092F8800486344 /* CheckListTemplateViewModel.swift in Sources */,
@@ -677,7 +676,7 @@
 				5FDC17C528FE799C0060DBB7 /* Workade.xcdatamodeld in Sources */,
 				16CBD45D290272F50056A641 /* CheckListDetailViewController.swift in Sources */,
 				0ED6D420290946B1000DF27B /* TempNavigationBar.swift in Sources */,
-        96433235290A776600FBECAF /* Constants.swift in Sources */,
+				96433235290A776600FBECAF /* Constants.swift in Sources */,
 				16CBD462290290910056A641 /* CheckListDetailCell.swift in Sources */,
 				A3947B2329013EE200DA4E0D /* CustomSegmentedControl.swift in Sources */,
 				5F28285C290793D800882FF3 /* BasePaddingLabel.swift in Sources */,

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		5F5C074E28FE81DE0089DD4B /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F5C074D28FE81DE0089DD4B /* HomeModel.swift */; };
 		5FBADE5029056811008CCC58 /* MapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FBADE4F29056811008CCC58 /* MapViewController.swift */; };
 		5FD1F5D2290A6BCB00744CCC /* MapPinModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD1F5D1290A6BCB00744CCC /* MapPinModel.swift */; };
-		5FD22E8C290B13A4003CF909 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD22E8B290B13A4003CF909 /* MapViewModel.swift */; };
+		5FD22E90290B17E2003CF909 /* MapViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD22E8E290B17E2003CF909 /* MapViewModel.swift */; };
 		5FDC17BB28FE799C0060DBB7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BA28FE799C0060DBB7 /* AppDelegate.swift */; };
 		5FDC17BD28FE799C0060DBB7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BC28FE799C0060DBB7 /* SceneDelegate.swift */; };
 		5FDC17BF28FE799C0060DBB7 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FDC17BE28FE799C0060DBB7 /* ViewController.swift */; };
@@ -130,7 +130,7 @@
 		5F5C074D28FE81DE0089DD4B /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		5FBADE4F29056811008CCC58 /* MapViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewController.swift; sourceTree = "<group>"; };
 		5FD1F5D1290A6BCB00744CCC /* MapPinModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapPinModel.swift; sourceTree = "<group>"; };
-		5FD22E8B290B13A4003CF909 /* MapViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
+		5FD22E8E290B17E2003CF909 /* MapViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MapViewModel.swift; sourceTree = "<group>"; };
 		5FDC17B728FE799C0060DBB7 /* Workade.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Workade.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5FDC17BA28FE799C0060DBB7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		5FDC17BC28FE799C0060DBB7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -329,8 +329,8 @@
 		5FBADE4E29056803008CCC58 /* Map */ = {
 			isa = PBXGroup;
 			children = (
+				5FD22E8E290B17E2003CF909 /* MapViewModel.swift */,
 				5FBADE4F29056811008CCC58 /* MapViewController.swift */,
-				5FD22E8B290B13A4003CF909 /* MapViewModel.swift */,
 			);
 			path = Map;
 			sourceTree = "<group>";
@@ -639,7 +639,6 @@
 				0E370E6529091B3A009C69BB /* DetailDataModel.swift in Sources */,
 				0EFB5BCB29017FBB00174291 /* GalleryView.swift in Sources */,
 				0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */,
-				5FD22E8C290B13A4003CF909 /* MapViewModel.swift in Sources */,
 				16CBD46A2902FB0F0056A641 /* UITableView+.swift in Sources */,
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,
 				2154A89B29092F8800486344 /* CheckListTemplateViewModel.swift in Sources */,
@@ -648,6 +647,7 @@
 				9643322D290A602F00FBECAF /* NetworkManager.swift in Sources */,
 				9646763C290932010047ED34 /* UINavigationController.swift in Sources */,
 				A393992629081628000E129A /* CustomNavigationBar.swift in Sources */,
+				5FD22E90290B17E2003CF909 /* MapViewModel.swift in Sources */,
 				16CBD46C2902FB480056A641 /* UITableViewCell+.swift in Sources */,
 				5F5C074828FE803C0089DD4B /* UIColor+.swift in Sources */,
 				16083B4C29013F9A008056D4 /* CheckListViewController.swift in Sources */,

--- a/Workade/AppDelegate.swift
+++ b/Workade/AppDelegate.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import CoreData
+import NMapsMap
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Workade/Models/HomeModel.swift
+++ b/Workade/Models/HomeModel.swift
@@ -49,10 +49,11 @@ struct Spot: Codable {
     }
 }
 
-enum SpotType {
+enum SpotType: String {
     case cafe
     case nature
     case restaurant
+    case sea
 }
 
 struct MagazineResource: Codable {

--- a/Workade/Views&ViewModels/Home/HomeViewController.swift
+++ b/Workade/Views&ViewModels/Home/HomeViewController.swift
@@ -220,7 +220,7 @@ extension HomeViewController: UICollectionViewDelegate {
 
 extension HomeViewController: OfficeCollectionViewCellDelegate {
     func didTapMapButton(office: Office) {
-        let viewController = MapViewController()
+        let viewController = MapViewController(office: office)
         viewController.modalPresentationStyle = .fullScreen
         present(viewController, animated: true)
     }

--- a/Workade/Views&ViewModels/Map/MapViewController.swift
+++ b/Workade/Views&ViewModels/Map/MapViewController.swift
@@ -9,12 +9,7 @@ import NMapsMap
 import UIKit
 
 class MapViewController: UIViewController {
-    // Binding 객체
-    var latitude = 33.533054
-    var longitude = 126.630947
-    var officeName = "제주 O-PEACE"
-    // 임시 설정 주변 정보
-    var nearbySpots = [Spot]()
+    private var viewModel: MapViewModel
     
     private var currentPin: NMFMarker? = nil {
         willSet(newVal) {
@@ -42,7 +37,7 @@ class MapViewController: UIViewController {
     private lazy var officeNameLabel: BasePaddingLabel = {
         var label = BasePaddingLabel(padding: UIEdgeInsets(top: 12, left: 40, bottom: 12, right: 40))
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.text = self.officeName
+        label.text = viewModel.officeName
         label.textAlignment = .center
         label.backgroundColor = .theme.background
         label.layer.masksToBounds = true
@@ -81,16 +76,10 @@ class MapViewController: UIViewController {
     }()
     
     init(office: Office) {
+        viewModel = MapViewModel(office: office)
         super.init(nibName: nil, bundle: nil)
-        self.latitude = office.latitude
-        self.longitude = office.longitude
-        self.officeName = office.officeName
-        self.nearbySpots = office.spots
     }
     
-    init() {
-        super.init(nibName: nil, bundle: nil)
-    }
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -165,7 +154,7 @@ extension MapViewController {
     
     /// 카메라를 입력 받은 위도 경도로 이동하는 함수
     private func setCameraMap() {
-        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: latitude, lng: longitude))
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: viewModel.latitude, lng: viewModel.longitude))
         cameraUpdate.animation = .none
         cameraUpdate.animationDuration = 1
         map.moveCamera(cameraUpdate)
@@ -202,7 +191,7 @@ extension MapViewController {
             return true
         }
         
-        for spot in nearbySpots {
+        for spot in viewModel.spots {
             let marker = NMFMarker()
             marker.position = NMGLatLng(lat: spot.latitude, lng: spot.longitude)
             marker.captionText = spot.title
@@ -217,7 +206,6 @@ extension MapViewController {
             case .nature: marker.tag = Pin.nature.rawValue
             case .sea: marker.tag = Pin.sea.rawValue
             case .restaurant: marker.tag = Pin.restaurant.rawValue
-            default: marker.tag = UInt.init(-1)
             }
             
             marker.mapView = map

--- a/Workade/Views&ViewModels/Map/MapViewModel.swift
+++ b/Workade/Views&ViewModels/Map/MapViewModel.swift
@@ -1,0 +1,22 @@
+//
+//  MapViewModel.swift
+//  Workade
+//
+//  Created by Inho Choi on 2022/10/28.
+//
+
+import UIKit
+
+struct MapViewModel {
+    let latitude: Double
+    let longitude: Double
+    let officeName: String
+    let spots: [Spot]
+    
+    init(office: Office) {
+        self.latitude = office.latitude
+        self.longitude = office.longitude
+        self.officeName = office.officeName
+        self.spots = office.spots
+    }
+}


### PR DESCRIPTION
# 배경
- Home과 연결을 해야합니다.
- ViewController가 비대하지는 것을 막기 위해서 ViewMdoel을 분리했습니다.

# 작업 내용
- MapViewController에서 ViewModel 분리

# 테스트 방법
1. 터미널을 활용하여 프로젝트가 있는 폴더에 들어간다.
2. `pod install` 을 입력한다.
3. 프로젝트를 열고 `AppDelegate`를 들어간다.    
3-1.`ìmport NMapsMap`을 입력해준다.  
3-2. `application(_, didFinishLaunchinWithOptions)`에 아래의 코드를 입력한다.  

`NMFAuthManager.shared().clientId = <드롭박스에 있는 key 참조>`  

# 리뷰 노트
- Home -> Map으로 잘 넘어가는지 확인 부탁드립니다.
