### PR TITLE
♻️ 내비게이션 바를 재 활성화 하고 이미지 깨지는 버그를 수정했습니다.

### DIFF
--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -107,13 +107,13 @@ class CellItemDetailViewController: UIViewController {
         bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -200)
         scrollView.delegate = self
         
-//        setupCustomNavigationBar()
+        setupCustomNavigationBar()
         setupScrollViewLayout()
         setupLayout()
     }
     
     func setupLayout() {
-//        view.addSubview(customNavigationBar.view)
+        view.addSubview(customNavigationBar.view)
         
         contentsContainer.addSubview(closeButton)
         NSLayoutConstraint.activate([
@@ -218,11 +218,11 @@ extension CellItemDetailViewController: UIScrollViewDelegate {
         let currentScrollYOffset = scrollView.contentOffset.y
         
         if currentScrollYOffset > defaultScrollYOffset {
-//            customNavigationBar.view.alpha = currentScrollYOffset / (topSafeArea + 259)
+            customNavigationBar.view.alpha = currentScrollYOffset / (topSafeArea + 259)
             titleImageView.alpha = 1 - (currentScrollYOffset / (topSafeArea + 259))
             closeButton.alpha = 1 - (currentScrollYOffset / (topSafeArea + 259))
         } else {
-//            customNavigationBar.view.alpha = 0
+            customNavigationBar.view.alpha = 0
             titleImageView.alpha = 1
             closeButton.alpha = 1
         }

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -33,6 +33,7 @@ class CellItemDetailViewController: UIViewController {
     let titleImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
@@ -104,9 +105,9 @@ class CellItemDetailViewController: UIViewController {
             await titleImageView.setImageURL(title: magazine.title, url: magazine.imageURL)
         }
         
-        bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -200)
+        bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor)
         scrollView.delegate = self
-        
+                
         setupCustomNavigationBar()
         setupScrollViewLayout()
         setupLayout()
@@ -183,7 +184,7 @@ class CellItemDetailViewController: UIViewController {
             titleImageView.heightAnchor.constraint(greaterThanOrEqualTo: imageContainer.heightAnchor),
             titleImageView.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
             titleImageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
-            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor)
+            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
         ])
     }
     

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -184,7 +184,7 @@ class CellItemDetailViewController: UIViewController {
             titleImageView.heightAnchor.constraint(greaterThanOrEqualTo: imageContainer.heightAnchor),
             titleImageView.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
             titleImageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
-            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
+            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor)
         ])
     }
     


### PR DESCRIPTION
# 배경
- 이미지 깨지는 현상 수정

# 작업 내용
- 내비게이션 바 활성화
- 이미지 깨지는 현상 수정

# 테스트 방법
- 시뮬레이터 실행을 한 후 매거진에서 셀을 클릭후 이미지를 확인합니다.
- 커스텀 내비게이션 바가 정상적으로 보이는지 확인합니다.
