### PR TITLE
♻️ 내비게이션 뷰의 Back Button을 수정하고 Close 버튼을 활성화 했습니다.

### DIFF
--- a/Workade/Share/CustomNavigationBar.swift
+++ b/Workade/Share/CustomNavigationBar.swift
@@ -60,6 +60,12 @@ class CustomNavigationBar: UIViewController {
         setupLayout()
     }
     
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        self.titleText = nil
+        self.rightButtonImage = nil
+    }
+    
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -107,13 +107,13 @@ class CellItemDetailViewController: UIViewController {
         bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -200)
         scrollView.delegate = self
         
-//        setupCustomNavigationBar()
+        setupCustomNavigationBar()
         setupScrollViewLayout()
         setupLayout()
     }
     
     func setupLayout() {
-//        view.addSubview(customNavigationBar.view)
+        view.addSubview(customNavigationBar.view)
         
         contentsContainer.addSubview(closeButton)
         NSLayoutConstraint.activate([
@@ -218,11 +218,11 @@ extension CellItemDetailViewController: UIScrollViewDelegate {
         let currentScrollYOffset = scrollView.contentOffset.y
         
         if currentScrollYOffset > defaultScrollYOffset {
-//            customNavigationBar.view.alpha = currentScrollYOffset / (topSafeArea + 259)
+            customNavigationBar.view.alpha = currentScrollYOffset / (topSafeArea + 259)
             titleImageView.alpha = 1 - (currentScrollYOffset / (topSafeArea + 259))
             closeButton.alpha = 1 - (currentScrollYOffset / (topSafeArea + 259))
         } else {
-//            customNavigationBar.view.alpha = 0
+            customNavigationBar.view.alpha = 0
             titleImageView.alpha = 1
             closeButton.alpha = 1
         }

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -193,7 +193,9 @@ class CellItemDetailViewController: UIViewController {
         
         customNavigationBar = CustomNavigationBar(titleText: titleLabel.text, rightButtonImage: UIImage(systemName: "bookmark", withConfiguration: config))
         customNavigationBar.view.alpha = 0
-        customNavigationBar.dismissAction = { [weak self] in self?.presentingViewController?.dismiss(animated: true)}
+        customNavigationBar.dismissAction = { [weak self] in
+            self?.presentingViewController?.dismiss(animated: true)
+        }
     }
     
     @objc

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -84,13 +84,14 @@ class CellItemDetailViewController: UIViewController {
         return view
     }()
     
-    private var customNavigationBar: CustomNavigationBar!
+    private var customNavigationBar = CustomNavigationBar()
     
     init(magazine: Magazine) {
         super.init(nibName: nil, bundle: nil)
         
         magazineDetailView.setupMagazineDetailData(magazine: magazine)
         self.magazine = magazine
+        
     }
     
     required init?(coder: NSCoder) {
@@ -115,6 +116,7 @@ class CellItemDetailViewController: UIViewController {
     
     func setupLayout() {
         view.addSubview(customNavigationBar.view)
+        
         
         contentsContainer.addSubview(closeButton)
         NSLayoutConstraint.activate([

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -33,6 +33,7 @@ class CellItemDetailViewController: UIViewController {
     let titleImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFill
+        imageView.clipsToBounds = true
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
         return imageView
@@ -104,9 +105,9 @@ class CellItemDetailViewController: UIViewController {
             await titleImageView.setImageURL(title: magazine.title, url: magazine.imageURL)
         }
         
-        bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -200)
+        bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor)
         scrollView.delegate = self
-        
+                
         setupCustomNavigationBar()
         setupScrollViewLayout()
         setupLayout()
@@ -183,7 +184,7 @@ class CellItemDetailViewController: UIViewController {
             titleImageView.heightAnchor.constraint(greaterThanOrEqualTo: imageContainer.heightAnchor),
             titleImageView.leadingAnchor.constraint(equalTo: imageContainer.leadingAnchor),
             titleImageView.trailingAnchor.constraint(equalTo: imageContainer.trailingAnchor),
-            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor)
+            titleImageView.bottomAnchor.constraint(equalTo: imageContainer.bottomAnchor),
         ])
     }
     

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -84,7 +84,7 @@ class CellItemDetailViewController: UIViewController {
         return view
     }()
     
-    private var customNavigationBar: UIViewController!
+    private var customNavigationBar: CustomNavigationBar!
     
     init(magazine: Magazine) {
         super.init(nibName: nil, bundle: nil)
@@ -107,7 +107,7 @@ class CellItemDetailViewController: UIViewController {
         
         bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor)
         scrollView.delegate = self
-                
+        
         setupCustomNavigationBar()
         setupScrollViewLayout()
         setupLayout()
@@ -193,6 +193,7 @@ class CellItemDetailViewController: UIViewController {
         
         customNavigationBar = CustomNavigationBar(titleText: titleLabel.text, rightButtonImage: UIImage(systemName: "bookmark", withConfiguration: config))
         customNavigationBar.view.alpha = 0
+        customNavigationBar.dismissAction = { [weak self] in self?.presentingViewController?.dismiss(animated: true)}
     }
     
     @objc

--- a/Workade/Views&ViewModels/Magazine/MagazineDetailView.swift
+++ b/Workade/Views&ViewModels/Magazine/MagazineDetailView.swift
@@ -86,10 +86,6 @@ class MagazineDetailView: UIView {
         stackView.addArrangedSubview(imageView)
     }
     
-    private func getImage(from url: URL, completion: @escaping (Data?, URLResponse?, Error?) -> Void) {
-        URLSession.shared.dataTask(with: url, completionHandler: completion).resume()
-    }
-    
     private func appendTextToStackView(_ content: String, _ font: String?, _ color: String?) {
         let label = UILabel()
         label.text = content

--- a/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
@@ -60,6 +60,7 @@ class MagazineViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .theme.background
         
+        setupNavigationBar()
         setupSegmentedControl()
         setupLayout()
         setupLayoutDetailView()
@@ -131,5 +132,23 @@ class MagazineViewController: UIViewController {
         default:
             return
         }
+    }
+    
+    
+    @objc
+    func popToHomeVC() {
+        navigationController?.popViewController(animated: true)
+    }
+}
+
+private extension MagazineViewController {
+    func setupNavigationBar() {
+        navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: SFSymbol.chevronLeft.image,
+            style: .done,
+            target: self,
+            action: #selector(popToHomeVC)
+        )
     }
 }

--- a/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
@@ -136,7 +136,7 @@ class MagazineViewController: UIViewController {
     
     
     @objc
-    func popToHomeVC() {
+    func popToHomeViewController() {
         navigationController?.popViewController(animated: true)
     }
 }
@@ -148,7 +148,7 @@ private extension MagazineViewController {
             image: SFSymbol.chevronLeft.image,
             style: .done,
             target: self,
-            action: #selector(popToHomeVC)
+            action: #selector(popToHomeViewController)
         )
     }
 }


### PR DESCRIPTION
# 배경
- 내비게이션 뷰의 Back 버튼 통일
- Close 버튼 활성화

# 작업 내용
- Close 버튼 활성화
- 내비게이션 뷰의 Back 버튼 수정

# 테스트 방법
- 매거진 으로 들어가는 뷰에서 백 버튼이 < 모양인지 확인
- 셀을 누른 후 스크롤 내리고 커스텀 내비 바에서 close 정상 작동 하는지 확인
