### PR TITLE
♻️ 이미지 fetch관련 몇 가지 수정했습니다.

### DIFF
--- a/Workade/Extentions/UIImageView+.swift
+++ b/Workade/Extentions/UIImageView+.swift
@@ -17,17 +17,17 @@ extension UIImageView {
     /// 캐시에 없다면 url을 가공하고, NetworkManager의 request메서드에 url을 전달하여 data를 받습니다.
     ///
     /// 받은 data를 기반으로 이미지뷰 자기 자신의 image에 바로 비동기적으로 image를 넣어주고, 불러오는데 성공한 해당 이미지를 ImageCacheManager의 setObject 메서드를 이용하여 캐시에 저장합니다.
-    func setImageURL(title id: String, url: String) async {
-        if let cachedImage = ImageCacheManager.shared.object(id: id) {
+    func setImageURL(_ urlString: String) async {
+        if let cachedImage = ImageCacheManager.shared.object(id: urlString) {
             self.image = cachedImage
             return
         }
-        guard let url = URL(string: url) else { return }
+        guard let url = URL(string: urlString) else { return }
         guard let data = await NetworkManager.shared.request(url: url) else { return }
         if let image = UIImage(data: data) {
             DispatchQueue.main.async { [weak self] in
                 self?.image = image
-                ImageCacheManager.shared.setObject(image: image, id: id)
+                ImageCacheManager.shared.setObject(image: image, id: urlString)
             }
         }
     }

--- a/Workade/Managers/BookmarkManager.swift
+++ b/Workade/Managers/BookmarkManager.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-@MainActor
 final class BookmarkManager {
     static let shared = BookmarkManager()
     

--- a/Workade/Views&ViewModels/CheckList/CheckListTemplate/CheckListTemplateCell.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListTemplate/CheckListTemplateCell.swift
@@ -112,7 +112,7 @@ class CheckListTemplateCell: UICollectionViewCell {
         self.titleLabel.attributedText = attributedStr
         self.imageView.image = nil
         task = Task {
-            await self.imageView.setImageURL(title: title, url: imageUrl)
+            await self.imageView.setImageURL(imageUrl)
         }
     }
     

--- a/Workade/Views&ViewModels/Home/CollectionView/MagazineCollectionViewCell.swift
+++ b/Workade/Views&ViewModels/Home/CollectionView/MagazineCollectionViewCell.swift
@@ -69,7 +69,7 @@ final class MagazineCollectionViewCell: UICollectionViewCell {
         setupBookmarkImage()
         // 이렇게 최초 구성 이미지를 nil로 해주면, 빠른 스크롤 시에 이전 이미지가 들어가있는 이미지 꼬임 현상을 다소 막아줄 수 있습니다. 그 후 불러와진 이미지가 정상적으로 자리잡게 됩니다.
         task = Task {
-            await backgroundImageView.setImageURL(title: magazine.title, url: magazine.imageURL)
+            await backgroundImageView.setImageURL(magazine.imageURL)
         }
     }
     

--- a/Workade/Views&ViewModels/Home/CollectionView/OfficeCollectionViewCell.swift
+++ b/Workade/Views&ViewModels/Home/CollectionView/OfficeCollectionViewCell.swift
@@ -85,7 +85,7 @@ final class OfficeCollectionViewCell: UICollectionViewCell {
         // 이렇게 최초 구성 이미지를 nil로 해주면, 빠른 스크롤 시에 이전 이미지가 들어가있는 이미지 꼬임 현상을 다소 막아줄 수 있습니다. 그 후 불러와진 이미지가 정상적으로 자리잡게 됩니다.
         backgroundImageView.image = nil
         task = Task {
-            await backgroundImageView.setImageURL(title: office.officeName, url: office.imageURL)
+            await backgroundImageView.setImageURL(office.imageURL)
         }
     }
     

--- a/Workade/Views&ViewModels/Home/HomeViewController.swift
+++ b/Workade/Views&ViewModels/Home/HomeViewController.swift
@@ -118,15 +118,14 @@ final class HomeViewController: UIViewController {
         setupScrollViewLayout()
         setupNavigationBar()
         setupLayout()
+        observingFetchComplete()
+        observingChangedMagazineId()
     }
 }
 
 extension HomeViewController: LaunchScreenTimingDelegate {
     func finishLaunchScreen() {
         setupStatusBar()
-        
-        observingFetchComplete()
-        observingChangedMagazineId()
     }
     
     override func viewWillAppear(_ animated: Bool) {

--- a/Workade/Views&ViewModels/Home/MultiBinder.swift
+++ b/Workade/Views&ViewModels/Home/MultiBinder.swift
@@ -37,7 +37,6 @@ final class MultiBinder<T> {
         listeners = listeners.filter { $0.place != place }
         listeners.append(Listener(place: place, block: block))
         fire()
-        print(listeners)
     }
 
     func remove(at place: Place) {

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -101,7 +101,7 @@ class CellItemDetailViewController: UIViewController {
         view.backgroundColor = .theme.background
         titleLabel.text = magazine.title
         task = Task {
-            await titleImageView.setImageURL(title: magazine.title, url: magazine.imageURL)
+            await titleImageView.setImageURL(magazine.imageURL)
         }
         
         bottomConstraints = magazineDetailView.bottomAnchor.constraint(equalTo: contentsContainer.bottomAnchor, constant: -200)

--- a/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
+++ b/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
@@ -76,7 +76,6 @@ extension MyPageViewController {
     
     private func observingChangedMagazineId() {
         viewModel.clickedMagazineId.bindAndFire { [weak self] id in
-            print("호출은 되냐")
             guard let self = self else { return }
             guard let index = self.viewModel.wishMagazines.firstIndex(where: { $0.title == id }) else { return }
             DispatchQueue.main.async {

--- a/Workade/Views&ViewModels/MyPage/MyPageViewModel.swift
+++ b/Workade/Views&ViewModels/MyPage/MyPageViewModel.swift
@@ -42,4 +42,8 @@ final class MyPageViewModel {
             isCompleteFetch.value = true
         }
     }
+    
+    deinit {
+        bookmarkManager.clickedMagazineId.remove(at: .myPage)
+    }
 }

--- a/Workade/Views&ViewModels/NearbyPlace/IntroduceViewModel.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/IntroduceViewModel.swift
@@ -40,11 +40,14 @@ class IntroduceViewModel {
     }
     
     func fetchImage(urlString: String) async -> UIImage {
+        if let cachedImage = ImageCacheManager.shared.object(id: urlString) {
+            return cachedImage
+        }
         guard let imageURL = URL(string: urlString) else { return UIImage()}
         let result = await networkManager.request(url: imageURL)
         guard let result = result else { return  UIImage()}
         guard let image = UIImage(data: result) else { return UIImage()}
-        
+        ImageCacheManager.shared.setObject(image: image, id: urlString)
         return image
     }
 }

--- a/Workade/Views&ViewModels/NearbyPlace/IntroduceViewModel.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/IntroduceViewModel.swift
@@ -41,7 +41,6 @@ class IntroduceViewModel {
     
     func fetchImage(urlString: String) async -> UIImage {
         guard let imageURL = URL(string: urlString) else { return UIImage()}
-        
         let result = await networkManager.request(url: imageURL)
         guard let result = result else { return  UIImage()}
         guard let image = UIImage(data: result) else { return UIImage()}

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceView.swift
@@ -191,7 +191,7 @@ class NearbyPlaceView: UIView {
         placeLabel.text = office.officeName
         locationLabel.text = office.regionName
         Task {
-            await placeImageView.setImageURL(title: office.officeName, url: office.imageURL)
+            await placeImageView.setImageURL(office.imageURL)
         }
     }
     

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
@@ -44,6 +44,7 @@ class NearbyPlaceViewController: UIViewController {
         return label
     }()
     
+    // FIXME: 현재 안 쓰는 버튼처럼 보이는데 일단 주석 남깁니다.
     private lazy var mapButton: UIButton = {
         let config = UIImage.SymbolConfiguration(pointSize: 22, weight: .medium, scale: .default)
         


### PR DESCRIPTION
# 배경
- 홈 화면에 이미지를 조금이라도 더 빠르게 로드시키고 싶습니다.
- 한 번 부른 이미지는 캐시에 저장하면 이후 API호출이 불필요하니 효율적입니다.

# 작업 내용
- 런치가 끝난 후에 이미지 로드를 시작하는 것이 아닌, viewDidLoad때부터 바로 이미지를 로드할 수 있도록 수정.
- 이미지 캐싱 key로 굳이 title을 넘기지않아도 될 것 같아서 urlString을 캐싱 key값으로 사용.
- 현재 사용하지않는 듯한 컴포넌트에 FIXME 마크다운으로 표시했습니다. 추후 확인 부탁드려요.
- 오피스 소개 페이지의 이미지도 한 번 불러왔을 경우 이미지 캐싱.
- 뷰모델 deinit시에는 북마크 매니저에 있는 연결된 클로저를 제거.
- deinit 구문 안에는 비동기 코드가 들어갈 수 없어서 bookmarkManager의 @MainActor 키워드를 삭제했습니다.

# 테스트 방법
- 속도적인 부분이라 많은 차이는 없을 수 있으나 시뮬레이터를 켜서 확인 가능합니다.

# 맺음말
- 커밋할 때, ♻️ 마크로 작성했어야했는데 지금 보니 ✨를 사용했네요. 다음 리팩토링 때는 수정하겠습니당.