### PR TITLE
🔥 브랜치 병합 과정에서 생긴 불필요한 코드를 제거했습니다.

### DIFF
--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceViewController.swift
@@ -246,7 +246,6 @@ extension NearbyPlaceViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         if indexPath.row == galleryViewModel.images.count - 1, galleryViewModel.isCanLoaded {
             Task { [weak self] in
-                guard let self
                 await self?.galleryViewModel.fetchImages()
                 self?.nearbyPlaceView.galleryView.collectionView.reloadData()
             }


### PR DESCRIPTION
# 배경
- 현재 main 브랜치에 올라간 잘못된 코드 사항을 수정하였습니다. 

# 작업 내용
- `guard let self`  에러가 나는 잘못된 구문 사용 제거

# 테스트 방법
- 기기 테스트

# 리뷰 노트
- 빌드 에러 여부 확인

# 스크린샷
- UI 변경사항 없음