### PR TITLE
✨ 오피스, 매거진 뷰컨트롤러의 세그먼트 컨트롤을 커스텀하였습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -82,6 +82,7 @@
 		96554EE22927C78C00BBE26A /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554EE12927C78C00BBE26A /* Divider.swift */; };
 		96554EE52927F16900BBE26A /* OfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554EE42927F16900BBE26A /* OfficeViewController.swift */; };
 		96554F292928EE9F00BBE26A /* EllipseSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */; };
+		96554F2B29290C4200BBE26A /* EllipseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554F2A29290C4200BBE26A /* EllipseButton.swift */; };
 		96601F4828FEEF9C0064FEE2 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96601F4728FEEF9C0064FEE2 /* UIImage+.swift */; };
 		96972ECF2903008800197DEE /* MagazineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */; };
 		96972ED12903011500197DEE /* CellImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ED02903011500197DEE /* CellImageView.swift */; };
@@ -193,6 +194,7 @@
 		96554EE12927C78C00BBE26A /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
 		96554EE42927F16900BBE26A /* OfficeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewController.swift; sourceTree = "<group>"; };
 		96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipseSegmentControl.swift; sourceTree = "<group>"; };
+		96554F2A29290C4200BBE26A /* EllipseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipseButton.swift; sourceTree = "<group>"; };
 		96601F4728FEEF9C0064FEE2 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineCollectionViewCell.swift; sourceTree = "<group>"; };
 		96972ED02903011500197DEE /* CellImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageView.swift; sourceTree = "<group>"; };
@@ -579,6 +581,7 @@
 				A393992529081628000E129A /* CustomNavigationBar.swift */,
 				A3947B2229013EE200DA4E0D /* CustomSegmentedControl.swift */,
 				96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */,
+				96554F2A29290C4200BBE26A /* EllipseButton.swift */,
 				9646763929092EBF0047ED34 /* TitleLabel.swift */,
 				5F28285B290793D800882FF3 /* BasePaddingLabel.swift */,
 				A3DD5E6D2917A193008FDFBF /* GradientView.swift */,
@@ -763,6 +766,7 @@
 				96554F292928EE9F00BBE26A /* EllipseSegmentControl.swift in Sources */,
 				0EFB5BCB29017FBB00174291 /* GalleryView.swift in Sources */,
 				0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */,
+				96554F2B29290C4200BBE26A /* EllipseButton.swift in Sources */,
 				16CBD46A2902FB0F0056A641 /* UITableView+.swift in Sources */,
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,
 				2154A89B29092F8800486344 /* CheckListTemplateViewModel.swift in Sources */,

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -76,7 +76,7 @@
 		96433239290A783100FBECAF /* Binder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96433238290A783100FBECAF /* Binder.swift */; };
 		9643323B290A9B2000FBECAF /* MyPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9643323A290A9B2000FBECAF /* MyPageViewModel.swift */; };
 		9646763829092D4A0047ED34 /* MyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646763729092D4A0047ED34 /* MyPageViewController.swift */; };
-		9646763A29092EBF0047ED34 /* TitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646763929092EBF0047ED34 /* TitleView.swift */; };
+		9646763A29092EBF0047ED34 /* TitleLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646763929092EBF0047ED34 /* TitleLabel.swift */; };
 		9646763F2909347C0047ED34 /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9646763E2909347C0047ED34 /* SettingViewController.swift */; };
 		96554E9C292779D200BBE26A /* CheckListNavigationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554E9B292779D200BBE26A /* CheckListNavigationCell.swift */; };
 		96554EE22927C78C00BBE26A /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554EE12927C78C00BBE26A /* Divider.swift */; };
@@ -186,7 +186,7 @@
 		96433238290A783100FBECAF /* Binder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binder.swift; sourceTree = "<group>"; };
 		9643323A290A9B2000FBECAF /* MyPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewModel.swift; sourceTree = "<group>"; };
 		9646763729092D4A0047ED34 /* MyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageViewController.swift; sourceTree = "<group>"; };
-		9646763929092EBF0047ED34 /* TitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleView.swift; sourceTree = "<group>"; };
+		9646763929092EBF0047ED34 /* TitleLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleLabel.swift; sourceTree = "<group>"; };
 		9646763E2909347C0047ED34 /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		96554E9B292779D200BBE26A /* CheckListNavigationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListNavigationCell.swift; sourceTree = "<group>"; };
 		96554EE12927C78C00BBE26A /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
@@ -576,7 +576,7 @@
 			children = (
 				A393992529081628000E129A /* CustomNavigationBar.swift */,
 				A3947B2229013EE200DA4E0D /* CustomSegmentedControl.swift */,
-				9646763929092EBF0047ED34 /* TitleView.swift */,
+				9646763929092EBF0047ED34 /* TitleLabel.swift */,
 				5F28285B290793D800882FF3 /* BasePaddingLabel.swift */,
 				A3DD5E6D2917A193008FDFBF /* GradientView.swift */,
 				96554EE12927C78C00BBE26A /* Divider.swift */,
@@ -763,7 +763,7 @@
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,
 				2154A89B29092F8800486344 /* CheckListTemplateViewModel.swift in Sources */,
 				9646763829092D4A0047ED34 /* MyPageViewController.swift in Sources */,
-				9646763A29092EBF0047ED34 /* TitleView.swift in Sources */,
+				9646763A29092EBF0047ED34 /* TitleLabel.swift in Sources */,
 				9643322D290A602F00FBECAF /* NetworkManager.swift in Sources */,
 				A393992629081628000E129A /* CustomNavigationBar.swift in Sources */,
 				5FD22E90290B17E2003CF909 /* MapViewModel.swift in Sources */,

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		96554E9C292779D200BBE26A /* CheckListNavigationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554E9B292779D200BBE26A /* CheckListNavigationCell.swift */; };
 		96554EE22927C78C00BBE26A /* Divider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554EE12927C78C00BBE26A /* Divider.swift */; };
 		96554EE52927F16900BBE26A /* OfficeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554EE42927F16900BBE26A /* OfficeViewController.swift */; };
+		96554F292928EE9F00BBE26A /* EllipseSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */; };
 		96601F4828FEEF9C0064FEE2 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96601F4728FEEF9C0064FEE2 /* UIImage+.swift */; };
 		96972ECF2903008800197DEE /* MagazineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */; };
 		96972ED12903011500197DEE /* CellImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ED02903011500197DEE /* CellImageView.swift */; };
@@ -191,6 +192,7 @@
 		96554E9B292779D200BBE26A /* CheckListNavigationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckListNavigationCell.swift; sourceTree = "<group>"; };
 		96554EE12927C78C00BBE26A /* Divider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Divider.swift; sourceTree = "<group>"; };
 		96554EE42927F16900BBE26A /* OfficeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewController.swift; sourceTree = "<group>"; };
+		96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipseSegmentControl.swift; sourceTree = "<group>"; };
 		96601F4728FEEF9C0064FEE2 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineCollectionViewCell.swift; sourceTree = "<group>"; };
 		96972ED02903011500197DEE /* CellImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageView.swift; sourceTree = "<group>"; };
@@ -576,6 +578,7 @@
 			children = (
 				A393992529081628000E129A /* CustomNavigationBar.swift */,
 				A3947B2229013EE200DA4E0D /* CustomSegmentedControl.swift */,
+				96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */,
 				9646763929092EBF0047ED34 /* TitleLabel.swift */,
 				5F28285B290793D800882FF3 /* BasePaddingLabel.swift */,
 				A3DD5E6D2917A193008FDFBF /* GradientView.swift */,
@@ -757,6 +760,7 @@
 				96433231290A746400FBECAF /* UIImageView+.swift in Sources */,
 				0E370E6529091B3A009C69BB /* OfficeDetailResource.swift in Sources */,
 				96554EE52927F16900BBE26A /* OfficeViewController.swift in Sources */,
+				96554F292928EE9F00BBE26A /* EllipseSegmentControl.swift in Sources */,
 				0EFB5BCB29017FBB00174291 /* GalleryView.swift in Sources */,
 				0EFB5BA52900E9D800174291 /* IntroduceView.swift in Sources */,
 				16CBD46A2902FB0F0056A641 /* UITableView+.swift in Sources */,

--- a/Workade/Share/EllipseButton.swift
+++ b/Workade/Share/EllipseButton.swift
@@ -1,0 +1,44 @@
+//
+//  EllipseButton.swift
+//  Workade
+//
+//  Created by Hyeonsoo Kim on 2022/11/19.
+//
+
+import UIKit
+
+/// 타원 모양의 버튼. EllipseSegmentControl에서 쓸 수 있도록 만들어졌습니다.
+///
+/// 원하면 그 외에서도 사용이 가능하지만, 현재 강조 색상 및 평소 색상은 고정되어있습니다.
+final class EllipseButton: UIButton {
+    init(title: String) {
+        super.init(frame: .zero)
+        setTitle(title, for: .normal)
+        setTitleColor(.theme.tertiary, for: .normal)
+        titleLabel?.font = .customFont(for: .footnote)
+        backgroundColor = .theme.groupedBackground
+        layer.cornerRadius = intrinsicContentSize.height/2
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        var padding: CGFloat?
+        let count = titleLabel?.text?.count ?? 1
+        switch count {
+        case 1: padding = 8 // 글자 수마다 너비 대략 11 차이.
+        case 2: padding = 19
+        default: padding = 28 // 3이상부터는 28로 고정.
+        } // button의 intrinsic size 최소 30. '한 글자와 두 글자가 동일' 및 '두 글자일 때와 세 글자일 때가 큰 차이 없음'. 고로 해당 케이스들만 커스텀.
+        return CGSize(width: super.intrinsicContentSize.width + padding!, height: 34)
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            backgroundColor = isSelected ? .theme.workadeBlue : .theme.groupedBackground
+            setTitleColor(isSelected ? .theme.background : .theme.tertiary, for: .normal)
+        }
+    }
+}

--- a/Workade/Share/EllipseSegmentControl.swift
+++ b/Workade/Share/EllipseSegmentControl.swift
@@ -51,11 +51,27 @@ final class EllipseSegmentControl: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 현재 눌린 버튼을 확인하고, select. 나머지 버튼 unselect. +) 인덱스 쏴주기 & 위치 체크
     private func changeCurrentSegmentIndex(new index: Int) {
         guard buttons.count > index else { return }
         buttons.forEach { $0.isSelected = false }
         buttons[index].isSelected = true
         delegate?.ellipseSegment(didSelectItemAt: index)
+        checkPostion(index)
+    }
+    
+    /// 눌린 버튼의 위치를 체크하고, 필요 시 적절히 잘 보이도록 스크롤하는 메서드.
+    private func checkPostion(_ index: Int) {
+        let buttonMinX = buttons[index].frame.minX
+        let buttonMaxX = buttons[index].frame.maxX
+        let contentOffset = scrollView.contentOffset.x
+        let scrollViewWidth = scrollView.frame.width
+        
+        if buttonMinX - contentOffset < 20 {
+            scrollView.setContentOffset(.init(x: buttonMinX - 20, y: 0), animated: true)
+        } else if (contentOffset + scrollViewWidth) - buttonMaxX < 20 {
+            scrollView.setContentOffset(.init(x: buttonMaxX - scrollViewWidth + 20, y: 0), animated: true)
+        }
     }
 }
 
@@ -91,34 +107,5 @@ private extension EllipseSegmentControl {
             stackView.bottomAnchor.constraint(equalTo: contentGuide.bottomAnchor),
             stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor)
         ])
-    }
-}
-
-/// 타원 모양의 버튼. EllipseSegmentControl에서 쓸 수 있도록 만들어졌습니다.
-///
-/// 원하면 그 외에서도 사용이 가능하지만, 현재 강조 색상 및 평소 색상은 고정되어있습니다.
-final class EllipseButton: UIButton {
-    init(title: String) {
-        super.init(frame: .zero)
-        setTitle(title, for: .normal)
-        setTitleColor(.theme.tertiary, for: .normal)
-        titleLabel?.font = .customFont(for: .footnote)
-        backgroundColor = .theme.groupedBackground
-        layer.cornerRadius = intrinsicContentSize.height/2
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
-    override var intrinsicContentSize: CGSize {
-        return CGSize(width: super.intrinsicContentSize.width + 20, height: 34)
-    }
-    
-    override var isSelected: Bool {
-        didSet {
-            backgroundColor = isSelected ? UIColor.blue : UIColor.lightGray
-            setTitleColor(isSelected ? .theme.workadeBlue : .theme.tertiary, for: .normal)
-        }
     }
 }

--- a/Workade/Share/EllipseSegmentControl.swift
+++ b/Workade/Share/EllipseSegmentControl.swift
@@ -1,0 +1,124 @@
+//
+//  EllipseSegmentControl.swift
+//  Workade
+//
+//  Created by Hyeonsoo Kim on 2022/11/19.
+//
+
+import UIKit
+
+protocol EllipseSegmentControlDelegate: AnyObject {
+    func ellipseSegment(didSelectItemAt index: Int)
+}
+
+/// 오피스, 매거진 뷰컨트롤러 등에서 사용되는 커스텀 타원형 세그먼트 컨트롤
+final class EllipseSegmentControl: UIView {
+    private var buttons = [UIButton]()
+    var currentSegmentIndex: Int = 0 { // Single Source
+        didSet {
+            changeCurrentSegmentIndex(new: currentSegmentIndex)
+        }
+    }
+    
+    weak var delegate: EllipseSegmentControlDelegate?
+    
+    private let scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.contentInset = .init(top: 0, left: 20, bottom: 0, right: 20)
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return scrollView
+    }()
+    
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.spacing = 8
+        stackView.alignment = .center
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return stackView
+    }()
+    
+    init(items: [String]) {
+        super.init(frame: .zero)
+        setupLayout()
+        configureSegment(items: items)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func changeCurrentSegmentIndex(new index: Int) {
+        guard buttons.count > index else { return }
+        buttons.forEach { $0.isSelected = false }
+        buttons[index].isSelected = true
+        delegate?.ellipseSegment(didSelectItemAt: index)
+    }
+}
+
+// MARK: UI Setup Related Methods
+private extension EllipseSegmentControl {
+    func configureSegment(items: [String]) {
+        items.enumerated().forEach { index, title in
+            let button = EllipseButton(title: title)
+            button.addAction(UIAction(handler: { [weak self] _ in
+                self?.currentSegmentIndex = index
+            }), for: .touchUpInside)
+            buttons.append(button)
+            stackView.addArrangedSubview(button)
+        }
+    }
+    
+    func setupLayout() {
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        let contentGuide = scrollView.contentLayoutGuide
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: contentGuide.topAnchor),
+            stackView.leadingAnchor.constraint(equalTo: contentGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: contentGuide.trailingAnchor),
+            stackView.bottomAnchor.constraint(equalTo: contentGuide.bottomAnchor),
+            stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor)
+        ])
+    }
+}
+
+/// 타원 모양의 버튼. EllipseSegmentControl에서 쓸 수 있도록 만들어졌습니다.
+///
+/// 원하면 그 외에서도 사용이 가능하지만, 현재 강조 색상 및 평소 색상은 고정되어있습니다.
+final class EllipseButton: UIButton {
+    init(title: String) {
+        super.init(frame: .zero)
+        setTitle(title, for: .normal)
+        setTitleColor(.theme.tertiary, for: .normal)
+        titleLabel?.font = .customFont(for: .footnote)
+        backgroundColor = .theme.groupedBackground
+        layer.cornerRadius = intrinsicContentSize.height/2
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var intrinsicContentSize: CGSize {
+        return CGSize(width: super.intrinsicContentSize.width + 20, height: 34)
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            backgroundColor = isSelected ? UIColor.blue : UIColor.lightGray
+            setTitleColor(isSelected ? .theme.workadeBlue : .theme.tertiary, for: .normal)
+        }
+    }
+}

--- a/Workade/Share/TitleLabel.swift
+++ b/Workade/Share/TitleLabel.swift
@@ -8,11 +8,11 @@
 import UIKit
 
 /// 마이페이지, 설정, 매거진, 체크리스트에서 공통적으로 사용하는 최상단 Title파트의 Label
-final class TitleView: UILabel {
+final class TitleLabel: UILabel {
     convenience init(title: String) {
         self.init(frame: .zero)
         text = title
-        font = .customFont(for: .title2)
+        font = .customFont(for: .title3)
         textColor = .theme.primary
         translatesAutoresizingMaskIntoConstraints = false
     }

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
@@ -46,9 +46,10 @@ final class GuideHomeViewController: UIViewController {
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: SFSymbol.chevronLeft.image,
-            style: .done,
-            target: self,
-            action: #selector(popViewController)
+            primaryAction: UIAction(handler: { [weak self] _ in
+                guard let self = self else { return }
+                self.navigationController?.popViewController(animated: true)
+            })
         )
     }
     
@@ -84,10 +85,6 @@ private extension GuideHomeViewController {
     func pushToCheckListVC() {
         let viewController = CheckListViewController()
         navigationController?.pushViewController(viewController, animated: true)
-    }
-    
-    @objc func popViewController() {
-        navigationController?.popViewController(animated: true)
     }
 }
 

--- a/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
@@ -10,6 +10,17 @@ import UIKit
 class MagazineViewController: UIViewController {
     private let titleView = TitleLabel(title: "매거진")
     
+    private lazy var ellipseSegment: UIView = {
+        let segment = EllipseSegmentControl(items: ["전체", "팁", "칼럼", "후기", "찜한 리스트"])
+        segment.delegate = self
+        segment.currentSegmentIndex = 0
+        segment.translatesAutoresizingMaskIntoConstraints = false
+        
+        return segment
+    }()
+    
+    private let divider = Divider()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.background
@@ -33,10 +44,30 @@ private extension MagazineViewController {
     
     func setupLayout() {
         view.addSubview(titleView)
+        view.addSubview(ellipseSegment)
+        view.addSubview(divider)
         
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
         ])
+        
+        NSLayoutConstraint.activate([
+            ellipseSegment.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 30),
+            ellipseSegment.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            ellipseSegment.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            ellipseSegment.heightAnchor.constraint(equalToConstant: 34)
+        ])
+        
+        NSLayoutConstraint.activate([
+            divider.topAnchor.constraint(equalTo: ellipseSegment.bottomAnchor, constant: 12),
+            divider.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+}
+
+extension MagazineViewController: EllipseSegmentControlDelegate {
+    func ellipseSegment(didSelectItemAt index: Int) {
+        print(index)
     }
 }

--- a/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/MagazineViewController.swift
@@ -8,121 +8,14 @@
 import UIKit
 
 class MagazineViewController: UIViewController {
-    // MARK: 컴포넌트 설정
-    private let viewTitle: UILabel = {
-        let label = UILabel()
-        label.text = "매거진"
-        label.font = .customFont(for: .title2)
-        label.textColor = .theme.primary
-        label.translatesAutoresizingMaskIntoConstraints = false
-        
-        return label
-    }()
-    
-    private lazy var customTab: UISegmentedControl = {
-        let segmentedControl = CustomSegmentedControl(items: ["전체", "팁", "칼럼", "후기"])
-        segmentedControl.translatesAutoresizingMaskIntoConstraints = false
-        segmentedControl.addTarget(self, action: #selector(tabClicked(tab:)), for: UIControl.Event.valueChanged)
-        
-        return segmentedControl
-    }()
-    
-    private let line: UIView = {
-        let line = UIView()
-        line.backgroundColor = .theme.quaternary
-        line.translatesAutoresizingMaskIntoConstraints = false
-        
-        return line
-    }()
-    
-    private let tapDetailViewContoller: TapDetailViewController = {
-        let viewController = TapDetailViewController()
-        viewController.view.translatesAutoresizingMaskIntoConstraints = false
-        
-        return viewController
-    }()
+    private let titleView = TitleLabel(title: "매거진")
     
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.background
         
         setupNavigationBar()
-        setupSegmentedControl()
         setupLayout()
-        setupLayoutDetailView()
-    }
-    
-    // MARK: AutoLayout 설정
-    private func setupLayout() {
-        
-        view.addSubview(viewTitle)
-        NSLayoutConstraint.activate([
-            viewTitle.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-            viewTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
-        ])
-        
-        view.addSubview(customTab)
-        NSLayoutConstraint.activate([
-            customTab.topAnchor.constraint(equalTo: viewTitle.bottomAnchor, constant: 14),
-            customTab.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            customTab.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            customTab.heightAnchor.constraint(equalToConstant: 50)
-        ])
-        
-        view.addSubview(line)
-        NSLayoutConstraint.activate([
-            line.topAnchor.constraint(equalTo: customTab.bottomAnchor, constant: 10),
-            line.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            line.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            line.heightAnchor.constraint(equalToConstant: 2)
-        ])
-    }
-    
-    private func setupLayoutDetailView() {
-        view.addSubview(tapDetailViewContoller.view)
-        NSLayoutConstraint.activate([
-            tapDetailViewContoller.view.topAnchor.constraint(equalTo: line.bottomAnchor),
-            tapDetailViewContoller.view.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            tapDetailViewContoller.view.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            tapDetailViewContoller.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
-    }
-    
-    func setupSegmentedControl() {
-        self.customTab.setTitleTextAttributes(
-            [
-                NSAttributedString.Key.foregroundColor: UIColor.theme.quaternary,
-                .font: UIFont.customFont(for: .headline)
-            ], for: .normal)
-        self.customTab.setTitleTextAttributes(
-            [
-                NSAttributedString.Key.foregroundColor: UIColor.theme.primary,
-                .font: UIFont.customFont(for: .headline)
-            ],
-            for: .selected
-        )
-        self.customTab.selectedSegmentIndex = 0
-    }
-    
-    @objc
-    func tabClicked(tab: UISegmentedControl) {
-        switch tab.selectedSegmentIndex {
-        case 0:
-            tapDetailViewContoller.tapDetailCollectionView.reloadData()
-        case 1:
-            tapDetailViewContoller.tapDetailCollectionView.reloadData()
-        case 2:
-            tapDetailViewContoller.tapDetailCollectionView.reloadData()
-        case 3:
-            tapDetailViewContoller.tapDetailCollectionView.reloadData()
-        default:
-            return
-        }
-    }
-    
-    @objc
-    func popToGuideHomeViewController() {
-        navigationController?.popViewController(animated: true)
     }
 }
 
@@ -131,9 +24,19 @@ private extension MagazineViewController {
         navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(
             image: SFSymbol.chevronLeft.image,
-            style: .done,
-            target: self,
-            action: #selector(popToGuideHomeViewController)
+            primaryAction: UIAction(handler: { [weak self] _ in
+                guard let self = self else { return }
+                self.navigationController?.popViewController(animated: true)
+            })
         )
+    }
+    
+    func setupLayout() {
+        view.addSubview(titleView)
+        
+        NSLayoutConstraint.activate([
+            titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+        ])
     }
 }

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -8,8 +8,35 @@
 import UIKit
 
 final class OfficeViewController: UIViewController {
+    private let titleView = TitleLabel(title: "오피스")
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemMint
+        view.backgroundColor = .theme.background
+        
+        setupNavigationBar()
+        setupLayout()
+    }
+}
+
+private extension OfficeViewController {
+    func setupNavigationBar() {
+        navigationItem.hidesBackButton = true
+        navigationItem.leftBarButtonItem = UIBarButtonItem(
+            image: SFSymbol.chevronLeft.image,
+            primaryAction: UIAction(handler: { [weak self] _ in
+                guard let self = self else { return }
+                self.navigationController?.popViewController(animated: true)
+            })
+        )
+    }
+    
+    func setupLayout() {
+        view.addSubview(titleView)
+        
+        NSLayoutConstraint.activate([
+            titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
+            titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+        ])
     }
 }

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -14,9 +14,12 @@ final class OfficeViewController: UIViewController {
         let segment = EllipseSegmentControl(items: ["전체", "제주", "양양", "고성", "경주", "포항"])
         segment.delegate = self
         segment.currentSegmentIndex = 0
+        segment.translatesAutoresizingMaskIntoConstraints = false
         
         return segment
     }()
+    
+    private let divider = Divider()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -41,16 +44,30 @@ private extension OfficeViewController {
     
     func setupLayout() {
         view.addSubview(titleView)
+        view.addSubview(ellipseSegment)
+        view.addSubview(divider)
         
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            ellipseSegment.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 30),
+            ellipseSegment.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            ellipseSegment.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            ellipseSegment.heightAnchor.constraint(equalToConstant: 34)
+        ])
+        
+        NSLayoutConstraint.activate([
+            divider.topAnchor.constraint(equalTo: ellipseSegment.bottomAnchor, constant: 12),
+            divider.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
 }
 
 extension OfficeViewController: EllipseSegmentControlDelegate {
     func ellipseSegment(didSelectItemAt index: Int) {
-        
+        print(index)
     }
 }

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -10,6 +10,14 @@ import UIKit
 final class OfficeViewController: UIViewController {
     private let titleView = TitleLabel(title: "오피스")
     
+    private lazy var ellipseSegment: UIView = {
+        let segment = EllipseSegmentControl(items: ["전체", "제주", "양양", "고성", "경주", "포항"])
+        segment.delegate = self
+        segment.currentSegmentIndex = 0
+        
+        return segment
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.background
@@ -38,5 +46,11 @@ private extension OfficeViewController {
             titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
             titleView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
         ])
+    }
+}
+
+extension OfficeViewController: EllipseSegmentControlDelegate {
+    func ellipseSegment(didSelectItemAt index: Int) {
+        
     }
 }

--- a/Workade/Views&ViewModels/SettingViewController/SettingViewController.swift
+++ b/Workade/Views&ViewModels/SettingViewController/SettingViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 final class SettingViewController: UIViewController {
-    private let titleView = TitleView(title: "설정")
+    private let titleView = TitleLabel(title: "설정")
     
     override func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
# 배경
- 전체 오피스 화면과, 전체 매거진 화면(뷰컨트롤러)에 새로 디자인된 세그먼트 컨트롤이 있습니다.

# 작업 내용
- OfficeViewController 초기 형태 구현
- 기존 MagazineViewController에서 바뀐 디자인으로 인해 불필요해진 로직 제거
- 커스텀 세그먼트 컨트롤 EllipseSegmentControl 정의
- 커스텀 세그먼트에서 사용하는 EllipseButton 정의
- 세그먼트를 스크롤뷰 + 스택뷰로 구현하여 추후 지역이 늘어나도 그에 맞게 늘어나고 스크롤 가능
- 스택뷰의 크기가 scrollView.frame.width - 40 보다 작을 경우 스크롤 불가능
- 특정 버튼 누를 경우, 해당 버튼의 index를 뷰컨트롤러가 수신받을 수 있음 (delegate)
- 세그먼트 버튼이 화면에 짤리거나 화면 가장자리와 20이하로 가까운 경우, 잘 보이도록 스크롤 이동. (현재 컨텐츠 수로는 해당하지않으나 추후를 생각해서)

# 테스트 방법
- 가이드 홈 화면에서 office 헤더 혹은 magazine 헤더 눌러서 들어가시면 됩니다.

# 스크린샷
- 컴포넌트 설명 (오피스 & 매거진)
<img src="https://user-images.githubusercontent.com/95853235/202855524-20330674-6d17-48a9-93e8-bf33a526429d.jpeg" width="500">

- 스크롤 예시용 영상
<img src="https://user-images.githubusercontent.com/95853235/202855759-1bc86ffe-bbbb-48db-a87d-f46fc5739c35.gif" width="300">