### PR TITLE
✨ OfficeViewController를 구성했습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		96601F4828FEEF9C0064FEE2 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96601F4728FEEF9C0064FEE2 /* UIImage+.swift */; };
 		96972ECF2903008800197DEE /* MagazineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */; };
 		96972ED12903011500197DEE /* CellImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ED02903011500197DEE /* CellImageView.swift */; };
+		96A28420292A6BB50084E479 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A2841F292A6BB50084E479 /* OfficeViewModel.swift */; };
 		96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B18367290142B7009F2BC6 /* UICollectionReuableView+.swift */; };
 		96B1836A29014361009F2BC6 /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B1836929014361009F2BC6 /* UICollectionView+.swift */; };
 		96B1836E290148D4009F2BC6 /* OfficeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B1836D290148D4009F2BC6 /* OfficeCollectionViewCell.swift */; };
@@ -202,6 +203,7 @@
 		96601F4728FEEF9C0064FEE2 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineCollectionViewCell.swift; sourceTree = "<group>"; };
 		96972ED02903011500197DEE /* CellImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageView.swift; sourceTree = "<group>"; };
+		96A2841F292A6BB50084E479 /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
 		96B18367290142B7009F2BC6 /* UICollectionReuableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReuableView+.swift"; sourceTree = "<group>"; };
 		96B1836929014361009F2BC6 /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		96B1836D290148D4009F2BC6 /* OfficeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -537,6 +539,7 @@
 			isa = PBXGroup;
 			children = (
 				96554EE42927F16900BBE26A /* OfficeViewController.swift */,
+				96A2841F292A6BB50084E479 /* OfficeViewModel.swift */,
 			);
 			path = Office;
 			sourceTree = "<group>";
@@ -833,6 +836,7 @@
 				96433235290A776600FBECAF /* Constants.swift in Sources */,
 				16CBD462290290910056A641 /* CheckListDetailCell.swift in Sources */,
 				A3947B2329013EE200DA4E0D /* CustomSegmentedControl.swift in Sources */,
+				96A28420292A6BB50084E479 /* OfficeViewModel.swift in Sources */,
 				16B2998A290B16E800136E62 /* CheckListBottomSheetViewModel.swift in Sources */,
 				A34AB347291B99C600065212 /* CGFloat+.swift in Sources */,
 				5F28285C290793D800882FF3 /* BasePaddingLabel.swift in Sources */,

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		96972ECF2903008800197DEE /* MagazineCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */; };
 		96972ED12903011500197DEE /* CellImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96972ED02903011500197DEE /* CellImageView.swift */; };
 		96A28420292A6BB50084E479 /* OfficeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A2841F292A6BB50084E479 /* OfficeViewModel.swift */; };
+		96A28422292A77E20084E479 /* PrepareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96A28421292A77E20084E479 /* PrepareView.swift */; };
 		96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B18367290142B7009F2BC6 /* UICollectionReuableView+.swift */; };
 		96B1836A29014361009F2BC6 /* UICollectionView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B1836929014361009F2BC6 /* UICollectionView+.swift */; };
 		96B1836E290148D4009F2BC6 /* OfficeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96B1836D290148D4009F2BC6 /* OfficeCollectionViewCell.swift */; };
@@ -204,6 +205,7 @@
 		96972ECE2903008800197DEE /* MagazineCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineCollectionViewCell.swift; sourceTree = "<group>"; };
 		96972ED02903011500197DEE /* CellImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CellImageView.swift; sourceTree = "<group>"; };
 		96A2841F292A6BB50084E479 /* OfficeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeViewModel.swift; sourceTree = "<group>"; };
+		96A28421292A77E20084E479 /* PrepareView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareView.swift; sourceTree = "<group>"; };
 		96B18367290142B7009F2BC6 /* UICollectionReuableView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionReuableView+.swift"; sourceTree = "<group>"; };
 		96B1836929014361009F2BC6 /* UICollectionView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UICollectionView+.swift"; sourceTree = "<group>"; };
 		96B1836D290148D4009F2BC6 /* OfficeCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfficeCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				5F28285B290793D800882FF3 /* BasePaddingLabel.swift */,
 				A3DD5E6D2917A193008FDFBF /* GradientView.swift */,
 				96554EE12927C78C00BBE26A /* Divider.swift */,
+				96A28421292A77E20084E479 /* PrepareView.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -789,6 +792,7 @@
 				16CBD46A2902FB0F0056A641 /* UITableView+.swift in Sources */,
 				96B18368290142B7009F2BC6 /* UICollectionReuableView+.swift in Sources */,
 				2154A89B29092F8800486344 /* CheckListTemplateViewModel.swift in Sources */,
+				96A28422292A77E20084E479 /* PrepareView.swift in Sources */,
 				9646763829092D4A0047ED34 /* MyPageViewController.swift in Sources */,
 				9646763A29092EBF0047ED34 /* TitleLabel.swift in Sources */,
 				9643322D290A602F00FBECAF /* NetworkManager.swift in Sources */,

--- a/Workade/Models/OfficeResource.swift
+++ b/Workade/Models/OfficeResource.swift
@@ -15,7 +15,8 @@ struct OfficeResource: Codable {
     }
 }
 
-struct OfficeModel: Codable {
+struct OfficeModel: Codable, Hashable {
+    let uuid = UUID()
     let officeName: String
     let regionName: String
     let imageURL: String
@@ -33,9 +34,14 @@ struct OfficeModel: Codable {
         case galleryURL = "galleryurl"
         case latitude, longitude, spots
     }
+    
+    // uuid를 해시값으로 삼겠다고 명시. (uuid 안쓰면, 다른 프로퍼티 중에서 알아서 기준값 잡아줌 <- 중복 위험있음)
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(uuid)
+    }
 }
 
-struct Spot: Codable {
+struct Spot: Codable, Hashable {
     let title: String
     let latitude: Double
     let longitude: Double

--- a/Workade/Share/Divider.swift
+++ b/Workade/Share/Divider.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class Divider: UIView {
+final class Divider: UIView {
     init() {
         super.init(frame: .zero)
         backgroundColor = .theme.groupedBackground

--- a/Workade/Share/PrepareView.swift
+++ b/Workade/Share/PrepareView.swift
@@ -20,8 +20,8 @@ final class PrepareView: UIView {
         }
     }
     
-    private let heartImageView: UIImageView = {
-        let imageView = UIImageView(image: UIImage(named: "heartIcon"))
+    private let prepareImageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: "folder")) // 임시 이미지. 추후 Asset PR 반영된 후 수정 예정.
         imageView.contentMode = .scaleAspectFit
         imageView.translatesAutoresizingMaskIntoConstraints = false
         
@@ -68,15 +68,15 @@ final class PrepareView: UIView {
     }
     
     private func setupLayout() {
-        addSubview(heartImageView)
+        addSubview(prepareImageView)
         addSubview(prepareLabel)
         addSubview(expectLabel)
         
         NSLayoutConstraint.activate([
-            heartImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
-            heartImageView.widthAnchor.constraint(equalToConstant: 100),
-            heartImageView.heightAnchor.constraint(equalToConstant: 100),
-            heartImageView.bottomAnchor.constraint(equalTo: prepareLabel.topAnchor, constant: -20)
+            prepareImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            prepareImageView.widthAnchor.constraint(equalToConstant: 100),
+            prepareImageView.heightAnchor.constraint(equalToConstant: 100),
+            prepareImageView.bottomAnchor.constraint(equalTo: prepareLabel.topAnchor, constant: -20)
         ])
         
         NSLayoutConstraint.activate([

--- a/Workade/Share/PrepareView.swift
+++ b/Workade/Share/PrepareView.swift
@@ -1,0 +1,92 @@
+//
+//  PrepareView.swift
+//  Workade
+//
+//  Created by Hyeonsoo Kim on 2022/11/20.
+//
+
+import UIKit
+
+enum GuideCategory {
+    case office(_ region: String)
+    case magazine
+}
+
+/// 현재 아직 컨텐츠가 없는 화면에 띄울 View
+final class PrepareView: UIView {
+    var category: GuideCategory? {
+        didSet {
+            setupText(category: category!)
+        }
+    }
+    
+    private let heartImageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: "heartIcon"))
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    
+    private let prepareLabel: UILabel = {
+        let label = UILabel()
+        label.font = .customFont(for: .captionHeadline)
+        label.textColor = .theme.primary
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let expectLabel: UILabel = {
+        let label = UILabel()
+        label.font = .customFont(for: .caption2)
+        label.textColor = .theme.tertiary
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupText(category: GuideCategory) {
+        switch category {
+        case .office(let regionName):
+            prepareLabel.text = "현재 준비중인 지역입니다."
+            expectLabel.text = "\(regionName) 편도 기대해주세요~!"
+        case .magazine:
+            prepareLabel.text = "현재 준비중인 컨텐츠입니다."
+        }
+    }
+    
+    private func setupLayout() {
+        addSubview(heartImageView)
+        addSubview(prepareLabel)
+        addSubview(expectLabel)
+        
+        NSLayoutConstraint.activate([
+            heartImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            heartImageView.widthAnchor.constraint(equalToConstant: 100),
+            heartImageView.heightAnchor.constraint(equalToConstant: 100),
+            heartImageView.bottomAnchor.constraint(equalTo: prepareLabel.topAnchor, constant: -20)
+        ])
+        
+        NSLayoutConstraint.activate([
+            prepareLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            prepareLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            expectLabel.topAnchor.constraint(equalTo: prepareLabel.bottomAnchor, constant: 10),
+            expectLabel.centerXAnchor.constraint(equalTo: centerXAnchor)
+        ])
+    }
+}

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
@@ -73,7 +73,7 @@ final class GuideHomeViewController: UIViewController {
 // MARK: Navigates
 private extension GuideHomeViewController {
     @objc func pushToOfficeVC() {
-        let viewController = OfficeViewController(from: "제주도")
+        let viewController = OfficeViewController()
         navigationController?.pushViewController(viewController, animated: true)
     }
     

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewController.swift
@@ -73,7 +73,7 @@ final class GuideHomeViewController: UIViewController {
 // MARK: Navigates
 private extension GuideHomeViewController {
     @objc func pushToOfficeVC() {
-        let viewController = OfficeViewController()
+        let viewController = OfficeViewController(from: "제주도")
         navigationController?.pushViewController(viewController, animated: true)
     }
     

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -36,6 +36,7 @@ final class OfficeViewController: UIViewController {
     
     private lazy var officeCollectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: viewModel.createLayout())
+        collectionView.delegate = self
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         
         return collectionView
@@ -168,5 +169,14 @@ extension OfficeViewController: EllipseSegmentControlDelegate {
     func ellipseSegment(didSelectItemAt index: Int) {
         let region = viewModel.regions[index]
         applySnapshot(region: region, animated: true)
+    }
+}
+
+extension OfficeViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let officeModel = snapshot.itemIdentifiers[indexPath.row]
+        let viewController = NearbyPlaceViewController(officeModel: officeModel)
+        viewController.modalPresentationStyle = .fullScreen
+        present(viewController, animated: true)
     }
 }

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -8,12 +8,15 @@
 import UIKit
 
 final class OfficeViewController: UIViewController {
-    private let titleView = TitleLabel(title: "오피스")
+    private let viewModel = OfficeViewModel()
     
     enum Section { case office }
     
     private var dataSource: UICollectionViewDiffableDataSource<Section, OfficeModel>!
     private var snapshot = NSDiffableDataSourceSnapshot<Section, OfficeModel>()
+    
+    // MARK: UI 컴포넌트
+    private let titleView = TitleLabel(title: "오피스")
     
     private lazy var ellipseSegment: UIView = {
         let segment = EllipseSegmentControl(items: ["전체", "제주", "양양", "고성", "경주", "포항"])
@@ -27,12 +30,13 @@ final class OfficeViewController: UIViewController {
     private let divider = Divider()
     
     private lazy var officeCollectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: viewModel.createLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         
         return collectionView
     }()
     
+    // MARK: viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.background

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -10,6 +10,11 @@ import UIKit
 final class OfficeViewController: UIViewController {
     private let titleView = TitleLabel(title: "오피스")
     
+    enum Section { case office }
+    
+    private var dataSource: UICollectionViewDiffableDataSource<Section, OfficeModel>!
+    private var snapshot = NSDiffableDataSourceSnapshot<Section, OfficeModel>()
+    
     private lazy var ellipseSegment: UIView = {
         let segment = EllipseSegmentControl(items: ["전체", "제주", "양양", "고성", "경주", "포항"])
         segment.delegate = self
@@ -21,15 +26,39 @@ final class OfficeViewController: UIViewController {
     
     private let divider = Divider()
     
+    private lazy var officeCollectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return collectionView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.background
         
         setupNavigationBar()
         setupLayout()
+        configureDataSource()
     }
 }
 
+// MARK: DiffableDataSource
+extension OfficeViewController {
+    func configureDataSource() {
+        // cell을 구성하고, 등록지를 만듬
+        let cellRegistration = UICollectionView.CellRegistration<OfficeCollectionViewCell, OfficeModel> { cell, _, itemIdentifier in
+            cell.configure(office: itemIdentifier)
+        }
+        
+        // collectionView와 dequeue cell을 제공하면서 dataSource 초기화
+        dataSource = UICollectionViewDiffableDataSource(collectionView: officeCollectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
+        })
+    }
+}
+
+// MARK: UI Related Methods
 private extension OfficeViewController {
     func setupNavigationBar() {
         navigationItem.hidesBackButton = true
@@ -66,6 +95,7 @@ private extension OfficeViewController {
     }
 }
 
+// MARK: Delegate
 extension OfficeViewController: EllipseSegmentControlDelegate {
     func ellipseSegment(didSelectItemAt index: Int) {
         print(index)

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -56,6 +56,16 @@ extension OfficeViewController {
             return collectionView.dequeueConfiguredReusableCell(using: cellRegistration, for: indexPath, item: itemIdentifier)
         })
     }
+    
+    func applySnapshot(animated: Bool) {
+        guard dataSource != nil else { return }
+        var snapshot = snapshot
+        snapshot.deleteAllItems()
+        snapshot.appendSections([Section.office])
+        snapshot.appendItems([])
+        self.dataSource.apply(snapshot, animatingDifferences: animated)
+        self.snapshot = snapshot // 이 순간에만 snapShot didset 호출될 수 있게 변수로 구성하고 넘기는 형태 구현함.
+    }
 }
 
 // MARK: UI Related Methods

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class OfficeViewController: UIViewController {
     private let viewModel = OfficeViewModel()
+    private let startRegion: String // 시작 화면 설정용
     
     enum Section { case office }
     private var dataSource: UICollectionViewDiffableDataSource<Section, OfficeModel>!
@@ -24,7 +25,8 @@ final class OfficeViewController: UIViewController {
     private lazy var ellipseSegment: EllipseSegmentControl = {
         let segment = EllipseSegmentControl(items: viewModel.regions)
         segment.delegate = self
-        segment.currentSegmentIndex = 0 // 여기
+        // 아직 서버에는 '제주도' <- 이렇게 되있어서 우선 contains를 사용.
+        segment.currentSegmentIndex = viewModel.regions.firstIndex(where: { startRegion.contains($0) }) ?? 0
         segment.translatesAutoresizingMaskIntoConstraints = false
         
         return segment
@@ -46,6 +48,11 @@ final class OfficeViewController: UIViewController {
         return prepareView
     }()
     
+    init(from region: String = "전체") { // 특정지역으로부터 올 때 -> OfficeViewController(from: "제주")
+        self.startRegion = region
+        super.init(nibName: nil, bundle: nil)
+    }
+    
     // MARK: viewDidLoad
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -63,6 +70,10 @@ final class OfficeViewController: UIViewController {
         viewModel.isCompleteFetch.bind { [weak self] _ in
             self?.applySnapshot(region: regionName, animated: true)
         }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
 }
 

--- a/Workade/Views&ViewModels/Office/OfficeViewController.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewController.swift
@@ -82,9 +82,9 @@ private extension OfficeViewController {
     }
     
     func setupLayout() {
-        view.addSubview(titleView)
-        view.addSubview(ellipseSegment)
-        view.addSubview(divider)
+        [titleView, ellipseSegment, divider, officeCollectionView].forEach {
+            view.addSubview($0)
+        }
         
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 10),
@@ -101,6 +101,13 @@ private extension OfficeViewController {
         NSLayoutConstraint.activate([
             divider.topAnchor.constraint(equalTo: ellipseSegment.bottomAnchor, constant: 12),
             divider.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+        
+        NSLayoutConstraint.activate([
+            officeCollectionView.topAnchor.constraint(equalTo: divider.bottomAnchor),
+            officeCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            officeCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            officeCollectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
     }
 }

--- a/Workade/Views&ViewModels/Office/OfficeViewModel.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewModel.swift
@@ -31,6 +31,7 @@ extension OfficeViewModel {
     /// filter and return data for diffableDataSource's snapshot
     func filteredOffice(region: String) -> [OfficeModel] {
         guard isCompleteFetch.value else { return [] }
+        // 아직 서버에는 '제주도' <- 이렇게 되있어서 우선 contains를 사용.
         return region == "전체" ? officeResource.content : officeResource.content.filter { $0.regionName.contains(region) }
     }
     

--- a/Workade/Views&ViewModels/Office/OfficeViewModel.swift
+++ b/Workade/Views&ViewModels/Office/OfficeViewModel.swift
@@ -1,0 +1,28 @@
+//
+//  OfficeViewModel.swift
+//  Workade
+//
+//  Created by Hyeonsoo Kim on 2022/11/20.
+//
+
+import UIKit
+
+@MainActor
+final class OfficeViewModel {
+    
+}
+
+extension OfficeViewModel {
+    typealias Size = NSCollectionLayoutSize
+    func createLayout() -> UICollectionViewLayout {
+        let itemSize = Size(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        let groupSize = Size(widthDimension: .fractionalWidth(1), heightDimension: .fractionalWidth(0.51))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = .init(top: 20, leading: 20, bottom: 30, trailing: 20)
+        section.interGroupSpacing = 20
+        
+        return UICollectionViewCompositionalLayout(section: section)
+    }
+}


### PR DESCRIPTION
# 배경
- 새로운 디자인에서 지역별 오피스들을 소개하는 페이지가 생겼습니다.
- 각 지역버튼을 누르면, 해당 지역의 오피스들이 나열됩니다.
- 오피스 셀을 누르면, 해당 오피스의 디테일뷰가 올라옵니다.

# 작업 내용
- OfficeCollectionView를 Compositional Layout으로 구성했습니다.
- OfficeCollectionView의 dataSource를 diffableDataSource를 사용하여 구성했습니다.
- 홈 화면을 통해 들어오는 경우, 세그먼트가 전체로 시작되고, 특정 지역에서 들어온 경우 해당 지역부터 화면이 시작됩니다.
- 아직 오피스 소개 컨텐츠가 없는 지역의 경우, 안내뷰(준비뷰)가 뜨도록 했습니다.
- 현재 안내뷰에는 임시로 "폴더 이미지"를 넣었고, 추후 Asset관련 PR이 합쳐진 후에 수정할 예정입니다.

# 테스트 방법
- 가이드 홈화면에서 오피스 헤더버튼을 눌러서 오피스 뷰컨트롤러로 들어가면 됩니다.

# 스크린샷
<div>
<img width="200" alt="스크린샷 2022-11-21 오전 2 03 29" src="https://user-images.githubusercontent.com/95853235/202915385-8469cc3a-dc26-420d-b8fa-0c8844db687b.png">
<img width="200" alt="스크린샷 2022-11-21 오전 2 03 17" src="https://user-images.githubusercontent.com/95853235/202915392-9359fafc-81cf-424a-abeb-b291605455c8.png">
</div>
</br>
추후 내부 컨텐츠가 많아지면 아래와 유사한 모습일 겁니다. (gif 프레임 수가 적은지 렉걸린 것처럼 보이네요...)
<img width="250" alt="스크린샷 2022-11-21 오전 2 03 17" src="https://user-images.githubusercontent.com/95853235/202915255-16e04c0a-2987-4f1d-b5cb-775e76a64cb5.gif">
