### PR TITLE
♻️ 오피스 배너 이미지와 매거진 배너 이미지의 크기를 통일시켰습니다. 

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -1222,7 +1222,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BXU6534P3P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";
@@ -1259,7 +1259,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = BXU6534P3P;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -1222,7 +1222,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BXU6534P3P;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";
@@ -1259,7 +1259,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BXU6534P3P;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";

--- a/Workade/Managers/MagazineTransitionManager.swift
+++ b/Workade/Managers/MagazineTransitionManager.swift
@@ -202,7 +202,7 @@ private extension MagazineTransitionManager {
             titleImageView.topAnchor.constraint(equalTo: containerView.topAnchor),
             titleImageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             titleImageView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
-            titleImageView.heightAnchor.constraint(equalToConstant: .topSafeArea + 375),
+            titleImageView.heightAnchor.constraint(equalToConstant: 375),
             
             bookmarkButton.topAnchor.constraint(equalTo: titleImageView.topAnchor),
             bookmarkButton.trailingAnchor.constraint(equalTo: titleImageView.trailingAnchor),

--- a/Workade/Managers/OfficeTransitionManager.swift
+++ b/Workade/Managers/OfficeTransitionManager.swift
@@ -43,6 +43,13 @@ final class OfficeTransitionManager: NSObject {
         copyPlaceView.placeLabel.reservations = [.init(.alpha, from: 0, to: 1, animated: isPresent)]
         copyPlaceView.locationLabel.reservations = [.init(.alpha, from: 0, to: 1, animated: isPresent)]
         
+        NSLayoutConstraint.activate([
+            copyPlaceView.imageView.topAnchor.constraint(equalTo: copyPlaceView.topAnchor),
+            copyPlaceView.imageView.leadingAnchor.constraint(equalTo: copyPlaceView.leadingAnchor),
+            copyPlaceView.imageView.trailingAnchor.constraint(equalTo: copyPlaceView.trailingAnchor),
+            copyPlaceView.imageView.bottomAnchor.constraint(equalTo: copyPlaceView.bottomAnchor)
+        ])
+        
         return copyPlaceView
     }
     

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -236,9 +236,9 @@ extension CellItemDetailViewController: UIScrollViewDelegate {
         if currentScrollYOffset > defaultScrollYOffset {
             setupCustomNavigationRightItem()
             titleImageView.setupBookmarkImage()
-            customNavigationBar.view.alpha = currentScrollYOffset / (.topSafeArea + 259)
-            titleImageView.alpha = 1 - (currentScrollYOffset / (.topSafeArea + 259))
-            closeButton.alpha = 1 - (currentScrollYOffset / (.topSafeArea + 259))
+            customNavigationBar.view.alpha = currentScrollYOffset / (375 - customNavigationBar.view.bounds.height)
+            titleImageView.alpha = 1 - (currentScrollYOffset / (375 - customNavigationBar.view.bounds.height))
+            closeButton.alpha = 1 - (currentScrollYOffset / (375 - customNavigationBar.view.bounds.height))
         } else {
             customNavigationBar.view.alpha = 0
             titleImageView.alpha = 1

--- a/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
+++ b/Workade/Views&ViewModels/Magazine/CellItemDetailViewController.swift
@@ -174,7 +174,7 @@ class CellItemDetailViewController: UIViewController {
         NSLayoutConstraint.activate([
             imageContainer.topAnchor.constraint(equalTo: contentsContainer.topAnchor),
             imageContainer.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            imageContainer.heightAnchor.constraint(equalToConstant: .topSafeArea + 375),
+            imageContainer.heightAnchor.constraint(equalToConstant: 375),
             imageContainer.widthAnchor.constraint(equalToConstant: UIScreen.main.bounds.width)
         ])
         

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceImageView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceImageView.swift
@@ -41,7 +41,6 @@ class NearbyPlaceImageView: UIView {
     }()
     
     init(officeModel: OfficeModel) {
-        print("중복중복")
         self.officeModel = officeModel
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false

--- a/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceImageView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/NearbyPlaceImageView.swift
@@ -41,6 +41,7 @@ class NearbyPlaceImageView: UIView {
     }()
     
     init(officeModel: OfficeModel) {
+        print("중복중복")
         self.officeModel = officeModel
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
@@ -69,15 +70,9 @@ class NearbyPlaceImageView: UIView {
     // AutoLayout
     private func setupLayout() {
         addSubview(imageView)
+        // imageView의 레이아웃은 상위 VC에서 맞춰줍니다.
         
         imageView.addSubview(locationLabel)
-        NSLayoutConstraint.activate([
-            imageView.topAnchor.constraint(equalTo: topAnchor),
-            imageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            imageView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            imageView.bottomAnchor.constraint(equalTo: bottomAnchor)
-        ])
-        
         NSLayoutConstraint.activate([
             locationLabel.bottomAnchor.constraint(equalTo: imageView.bottomAnchor, constant: -20),
             locationLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor, constant: 20)


### PR DESCRIPTION
# 배경
- 오피스 배너 이미지 사이즈와, 매거진 배너 이미지의 크기가 달랐습니다.

# 작업 내용
- 기존 매거진 배너 이미지에 topSafeArea만큼 크기가 더 들어가 있었던 것을 제거하였습니다.

# 테스트 방법
- 오피스 시트와, 매거진 시트를 눌러보고 배너 이미지의 크기를 비교합니다.

# 리뷰 노트
- 에반에게 디자인 관련하여 물어보고 진행하였습니다.

# 스크린샷
<div>
<img width="200" alt="스크린샷" src="https://user-images.githubusercontent.com/75309495/204463802-923097e9-0593-4625-abfd-49c539480813.png">
<img width="200" alt="스크린샷" src="https://user-images.githubusercontent.com/75309495/204463848-831facc6-6b6c-407f-a7aa-7f46fe2cc77d.png">
</div>