### PR TITLE
✨ 네트워크 상태를 체크하는 NetworkMonitor 객체를 정의 및 연결했습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -1318,7 +1318,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = B2RV52W8G3;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		96554F292928EE9F00BBE26A /* EllipseSegmentControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */; };
 		96554F2B29290C4200BBE26A /* EllipseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96554F2A29290C4200BBE26A /* EllipseButton.swift */; };
 		96601F4828FEEF9C0064FEE2 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96601F4728FEEF9C0064FEE2 /* UIImage+.swift */; };
+		968C5EC7293A6FB300D222BE /* NetworkMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 968C5EC6293A6FB300D222BE /* NetworkMonitor.swift */; };
 		9690404D292AB61500F5E590 /* MagazineCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9690404C292AB61500F5E590 /* MagazineCategory.swift */; };
 		969285E2292E64F8008F0389 /* MagazineTransitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969285E1292E64F8008F0389 /* MagazineTransitionManager.swift */; };
 		969285E6292E92DB008F0389 /* TitleImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 969285E5292E92DB008F0389 /* TitleImageView.swift */; };
@@ -286,6 +287,7 @@
 		96554F282928EE9F00BBE26A /* EllipseSegmentControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipseSegmentControl.swift; sourceTree = "<group>"; };
 		96554F2A29290C4200BBE26A /* EllipseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EllipseButton.swift; sourceTree = "<group>"; };
 		96601F4728FEEF9C0064FEE2 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		968C5EC6293A6FB300D222BE /* NetworkMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitor.swift; sourceTree = "<group>"; };
 		9690404C292AB61500F5E590 /* MagazineCategory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineCategory.swift; sourceTree = "<group>"; };
 		969285E1292E64F8008F0389 /* MagazineTransitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MagazineTransitionManager.swift; sourceTree = "<group>"; };
 		969285E5292E92DB008F0389 /* TitleImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleImageView.swift; sourceTree = "<group>"; };
@@ -723,6 +725,7 @@
 				21FC23E6293732D700606436 /* ExploreTransitionManager.swift */,
 				160572BD292CFB9900B4EE40 /* CoreDataManager.swift */,
 				5F5D33B42937234300C8F80C /* UserManager.swift */,
+				968C5EC6293A6FB300D222BE /* NetworkMonitor.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";
@@ -1008,6 +1011,7 @@
 				2120F56A290134D10035D36E /* GalleryCollectionViewCell.swift in Sources */,
 				169E1F01292A5A5E007F9E0A /* GradientButton.swift in Sources */,
 				961CC483290AF34600921F24 /* MultiBinder.swift in Sources */,
+				968C5EC7293A6FB300D222BE /* NetworkMonitor.swift in Sources */,
 				0EFCAA02292D240C00C84817 /* String+.swift in Sources */,
 				96433239290A783100FBECAF /* Binder.swift in Sources */,
 				5F83AD18292CEB1200F5CFB4 /* LoginNameViewController.swift in Sources */,

--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -1318,7 +1318,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = B2RV52W8G3;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Workade/Info.plist;
 				INFOPLIST_KEY_NSLocationAlwaysAndWhenInUseUsageDescription = "위치기반 워케이션 활동을 위해 GPS 정보가 필요합니다.";

--- a/Workade/Managers/NetworkMonitor.swift
+++ b/Workade/Managers/NetworkMonitor.swift
@@ -1,0 +1,40 @@
+//
+//  NetworkMonitor.swift
+//  Workade
+//
+//  Created by Hyeonsoo Kim on 2022/12/03.
+//
+
+import Combine
+import Network
+
+final class NetworkMonitor {
+    // Role - trigger&interface
+    let becomeSatisfied = PassthroughSubject<Void, Never>()
+    
+    private var monitor: NWPathMonitor?
+    private var status = NWPath.Status.satisfied {
+        didSet {
+            if oldValue == .unsatisfied && status == .satisfied {
+                becomeSatisfied.send()
+            }
+        }
+    }
+    
+    init() {
+        startMonitoring()
+    }
+    
+    private func startMonitoring() {
+        monitor = NWPathMonitor()
+        monitor?.start(queue: DispatchQueue.global(qos: .background))
+        monitor?.pathUpdateHandler = { [weak self] path in
+            self?.status = path.status
+        }
+    }
+    
+    private func stopMonitoring() {
+        monitor?.cancel()
+        monitor = nil
+    }
+}

--- a/Workade/Managers/NetworkMonitor.swift
+++ b/Workade/Managers/NetworkMonitor.swift
@@ -13,6 +13,10 @@ final class NetworkMonitor {
         startMonitoring()
     }
     
+    deinit {
+        stopMonitoring()
+    }
+    
     // interface 파트
     let becomeSatisfied = PassthroughSubject<Void, Never>()
     
@@ -26,5 +30,9 @@ final class NetworkMonitor {
                 self?.becomeSatisfied.send()
             }
         }
+    }
+    
+    private func stopMonitoring() {
+        monitor.cancel()
     }
 }

--- a/Workade/Managers/NetworkMonitor.swift
+++ b/Workade/Managers/NetworkMonitor.swift
@@ -18,18 +18,13 @@ final class NetworkMonitor {
     
     // 구현 파트
     private var monitor = NWPathMonitor()
-    private var status = NWPath.Status.unsatisfied {
-        didSet {
-            if status == .satisfied {
-                becomeSatisfied.send()
-            }
-        }
-    }
     
     private func startMonitoring() {
         monitor.start(queue: DispatchQueue.global(qos: .background))
         monitor.pathUpdateHandler = { [weak self] path in
-            self?.status = path.status
+            if path.status == .satisfied {
+                self?.becomeSatisfied.send()
+            }
         }
     }
 }

--- a/Workade/Managers/NetworkMonitor.swift
+++ b/Workade/Managers/NetworkMonitor.swift
@@ -9,32 +9,27 @@ import Combine
 import Network
 
 final class NetworkMonitor {
-    // Role - trigger&interface
+    init() {
+        startMonitoring()
+    }
+    
+    // interface 파트
     let becomeSatisfied = PassthroughSubject<Void, Never>()
     
-    private var monitor: NWPathMonitor?
-    private var status = NWPath.Status.satisfied {
+    // 구현 파트
+    private var monitor = NWPathMonitor()
+    private var status = NWPath.Status.unsatisfied {
         didSet {
-            if oldValue == .unsatisfied && status == .satisfied {
+            if status == .satisfied {
                 becomeSatisfied.send()
             }
         }
     }
     
-    init() {
-        startMonitoring()
-    }
-    
     private func startMonitoring() {
-        monitor = NWPathMonitor()
-        monitor?.start(queue: DispatchQueue.global(qos: .background))
-        monitor?.pathUpdateHandler = { [weak self] path in
+        monitor.start(queue: DispatchQueue.global(qos: .background))
+        monitor.pathUpdateHandler = { [weak self] path in
             self?.status = path.status
         }
-    }
-    
-    private func stopMonitoring() {
-        monitor?.cancel()
-        monitor = nil
     }
 }

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
@@ -31,7 +31,6 @@ final class GuideHomeViewModel {
             .sink { [weak self] _ in
                 guard let self = self else { return }
                 self.requestHomeData()
-                self.isCompleteFetch.value = true
                 self.networkMonitor = nil
             }
     }

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
@@ -12,8 +12,8 @@ import Combine
 final class GuideHomeViewModel {
     typealias Size = NSCollectionLayoutSize
     private var bookmarkManager = BookmarkManager.shared
-    private var networkMonitor = NetworkMonitor()
-    private var anycancellables = Set<AnyCancellable>()
+    private var networkMonitor: NetworkMonitor? = NetworkMonitor()
+    private var anyCancellable: AnyCancellable?
     
     private(set) var officeResource = OfficeResource()
     private(set) var magazineResource = MagazineResource()
@@ -28,12 +28,11 @@ final class GuideHomeViewModel {
     }
     
     private func bindMonitor() {
-        networkMonitor.becomeSatisfied
+        anyCancellable = networkMonitor?.becomeSatisfied
             .sink { [weak self] _ in
-                print("트리거왔다.")
                 self?.isCompleteFetch.value = true
+                self?.networkMonitor = nil
             }
-            .store(in: &anycancellables)
     }
     
     private func requestHomeData() {

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
@@ -6,11 +6,14 @@
 //
 
 import UIKit
+import Combine
 
 @MainActor
 final class GuideHomeViewModel {
     typealias Size = NSCollectionLayoutSize
     private var bookmarkManager = BookmarkManager.shared
+    private var networkMonitor = NetworkMonitor()
+    private var anycancellables = Set<AnyCancellable>()
     
     private(set) var officeResource = OfficeResource()
     private(set) var magazineResource = MagazineResource()
@@ -19,8 +22,18 @@ final class GuideHomeViewModel {
     private(set) var isCompleteFetch = Binder(false)
     
     init() {
+        bindMonitor()
         requestHomeData()
         bindingBookmarkManager() // 북마크
+    }
+    
+    private func bindMonitor() {
+        networkMonitor.becomeSatisfied
+            .sink { [weak self] _ in
+                print("트리거왔다.")
+                self?.isCompleteFetch.value = true
+            }
+            .store(in: &anycancellables)
     }
     
     private func requestHomeData() {

--- a/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
+++ b/Workade/Views&ViewModels/GuideHome/GuideHomeViewModel.swift
@@ -23,15 +23,16 @@ final class GuideHomeViewModel {
     
     init() {
         bindMonitor()
-        requestHomeData()
         bindingBookmarkManager() // 북마크
     }
     
     private func bindMonitor() {
         anyCancellable = networkMonitor?.becomeSatisfied
             .sink { [weak self] _ in
-                self?.isCompleteFetch.value = true
-                self?.networkMonitor = nil
+                guard let self = self else { return }
+                self.requestHomeData()
+                self.isCompleteFetch.value = true
+                self.networkMonitor = nil
             }
     }
     

--- a/Workade/Views&ViewModels/Login/LoginView.swift
+++ b/Workade/Views&ViewModels/Login/LoginView.swift
@@ -74,7 +74,7 @@ class  LoginView: UIView {
         self.buttonAction = action
         super.init(frame: .zero)
         backgroundColor = .blue
-        layer.cornerRadius = 32
+        layer.cornerRadius = 30
         
         setupLayout()
         setupLoginButtonLayout()


### PR DESCRIPTION
# 배경
- 가이드 홈 화면에 네트워크 꺼진 상태로 들어왔다가 이후에 키게 되면, 특정 트리거가 없기에 이미지는 불러와지지않습니다.

# 작업 내용
- swift의 Network 프레임워크에서 NWPathMonitor를 사용하여 네트워크를 모니터링하도록 했습니다.
- 이미 네트워크 환경이 만족된 상태면, 즉시 알립니다. 꺼진 상태라면 만족 상태로 전환되었을 때 알립니다.
- GuideHomeViewModel에서 신호를 받을 준비를 하고 있고, 신호 받은 후에는 NetworkMonitor가 불필요해지기에 nil을 주어 메모리 해제 시킵니다.

# 테스트 방법
- 실기기 상태에서 네트워크를 끈 채로 가이드홈 페이지를 들어간 후, 다시 켰을 때 잘 리로드되는지 확인하시면 됩니다.