### PR TITLE
✨ 웹뷰 호출로 License와 개인정보 처리 방침을 적용 하였습니다.

### DIFF
--- a/Workade/Views&ViewModels/MyPage/Setting/SettingViewController.swift
+++ b/Workade/Views&ViewModels/MyPage/Setting/SettingViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Hyeonsoo Kim on 2022/10/26.
 //
 
+import SafariServices
 import FirebaseAuth
 import UIKit
 
@@ -34,11 +35,12 @@ final class SettingViewController: UIViewController {
         return label
     }()
     
-    private let dataButton: SettingButton = {
-        let button = SettingButton(text: "데이터")
-        button.addAction(UIAction(handler: { _ in
-            // TODO: 데이터 뷰 이동
-            print("데이터 버튼 클릭")
+    private lazy var dataButton: SettingButton = {
+        let button = SettingButton(text: "개인정보 처리 방침")
+        button.addAction(UIAction(handler: { [weak self] _ in
+            guard let privacyPoliceURL = URL(string: "https://raw.githubusercontent.com/IIION/WorkadeData/main/ILION.md") else { return }
+            let privacyPoliceSafariView: SFSafariViewController = SFSafariViewController(url: privacyPoliceURL)
+            self?.present(privacyPoliceSafariView, animated: true, completion: nil)
         }), for: .touchUpInside)
         
         button.translatesAutoresizingMaskIntoConstraints = false
@@ -46,11 +48,12 @@ final class SettingViewController: UIViewController {
         return button
     }()
     
-    private let licenseButton: SettingButton = {
+    private lazy var licenseButton: SettingButton = {
         let button = SettingButton(text: "라이센스")
-        button.addAction(UIAction(handler: { _ in
-            // TODO: 라이센스 뷰 이동
-            print("라이센스 버튼 클릭")
+        button.addAction(UIAction(handler: { [weak self] _ in
+            guard let licenseURL = URL(string: "https://raw.githubusercontent.com/IIION/WorkadeData/main/License.md") else { return }
+            let licenseSafariView: SFSafariViewController = SFSafariViewController(url: licenseURL)
+            self?.present(licenseSafariView, animated: true, completion: nil)
         }), for: .touchUpInside)
         
         button.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
# 배경
- License와 개인정보 처리 방침 버튼활성화

# 작업 내용
-  License와 개인정보 처리 방침 웹뷰 호출

# 테스트 방법
- 내 정보 페이지에서 설정으로 들어가 각각의 버튼을 누릅니다.

# 리뷰 노트
- 라이센스 ViewController를 별도로 만들지 않고 개인정보 처리 방침과 같이 웹뷰 호출로 구성하였습니다.
- 통일성 및 추후 라이센스 내용을 바꾸기 위해서 앱 내에서 수정하려면 업데이트를 해야 하기 때문에 웹에서 라이센스 내용을 관리하는게 나을것 같습니다 다른분들의 생각은 어떠신가요 ?
- 해당 데이터는 WorkadeData 레포지토리에 첨부되어 있습니다.