### PR TITLE
♻️ 준비중인 지역에서 dismiss 버튼 노출 및 활성화

### DIFF
--- a/Workade/Managers/FirebaseManager.swift
+++ b/Workade/Managers/FirebaseManager.swift
@@ -28,7 +28,6 @@ final class FirebaseManager: NSObject {
         authorizationController.presentationContextProvider = self
     }
     
-    
     func touchUpAppleButton(region: Region?, appleSignupCompletion: @escaping () -> Void, appleSigninCompletion: @escaping () -> Void) {
         self.region = region
         self.appleSigninCompletion = appleSigninCompletion

--- a/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailCell/CheckListDetailCell.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailCell/CheckListDetailCell.swift
@@ -48,7 +48,7 @@ class CheckListDetailCell: UITableViewCell {
     
     func setupCell(todo: Todo) {
         checkButton.setImage(todo.done ? UIImage(systemName: "checkmark.circle.fill") : UIImage(systemName: "circle"), for: .normal)
-        checkButton.tintColor = todo.done ? .theme.workadeBlue : .theme.primary 
+        checkButton.tintColor = todo.done ? .theme.workadeBlue : .theme.primary
         contentText.text = todo.content
     }
 }

--- a/Workade/Views&ViewModels/Explore/ExploreViewController.swift
+++ b/Workade/Views&ViewModels/Explore/ExploreViewController.swift
@@ -302,5 +302,18 @@ final class ExploreViewController: UIViewController {
         } else {
             self.mainContainerView.image = UIImage(named: "")
         }
+        
+        setupDismissButtonColor()
+    }
+    
+    private func setupDismissButtonColor() {
+        var image: UIImage? = UIImage()
+        
+        if regionInfoView.warningView.isHidden {
+            image = UIImage.fromSystemImage(name: "xmark", font: .systemFont(ofSize: 15, weight: .bold), color: .theme.primary)?.withRenderingMode(.alwaysOriginal)
+        } else {
+            image = UIImage.fromSystemImage(name: "xmark", font: .systemFont(ofSize: 15, weight: .bold), color: .theme.background)?.withRenderingMode(.alwaysOriginal)
+        }
+        regionInfoView.dismissButton.setImage(image, for: .normal)
     }
 }

--- a/Workade/Views&ViewModels/Explore/RegionInfoView.swift
+++ b/Workade/Views&ViewModels/Explore/RegionInfoView.swift
@@ -71,10 +71,8 @@ final class RegionInfoView: UIView {
         return button
     }()
     
-    private lazy var dismissButton: UIButton = {
+    lazy var dismissButton: UIButton = {
         let button = UIButton(type: .custom)
-        let image = UIImage.fromSystemImage(name: "xmark", font: .systemFont(ofSize: 15, weight: .bold))?.withRenderingMode(.alwaysOriginal)
-        button.setImage(image, for: .normal)
         button.addAction(UIAction(handler: { [weak self] _ in
             self?.selectedRegion.value = nil
         }), for: .touchUpInside)
@@ -159,14 +157,6 @@ final class RegionInfoView: UIView {
             completion()
         }, for: .touchUpInside)
         
-        self.addSubview(dismissButton)
-        NSLayoutConstraint.activate([
-            dismissButton.widthAnchor.constraint(equalToConstant: 28),
-            dismissButton.heightAnchor.constraint(equalToConstant: 28),
-            dismissButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
-            dismissButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 20)
-        ])
-        
         self.addSubview(warningView)
         warningView.isHidden = true
         NSLayoutConstraint.activate([
@@ -174,6 +164,14 @@ final class RegionInfoView: UIView {
             warningView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
             warningView.topAnchor.constraint(equalTo: self.topAnchor),
             warningView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        ])
+        
+        self.addSubview(dismissButton)
+        NSLayoutConstraint.activate([
+            dismissButton.widthAnchor.constraint(equalToConstant: 28),
+            dismissButton.heightAnchor.constraint(equalToConstant: 28),
+            dismissButton.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -20),
+            dismissButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 20)
         ])
     }
     

--- a/Workade/Views&ViewModels/Login/LoginName/LoginNameViewController.swift
+++ b/Workade/Views&ViewModels/Login/LoginName/LoginNameViewController.swift
@@ -54,8 +54,6 @@ final class LoginNameViewController: UIViewController, UITextFieldDelegate {
         fatalError("init(coder:) has not been implemented")
     }
     
-    
-    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white

--- a/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
+++ b/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
@@ -8,7 +8,7 @@
 import Combine
 import UIKit
 
-final class MyPageViewController: UIViewController {    
+final class MyPageViewController: UIViewController {
     // 특정 모서리만 둥글게 처리 참고 사이트 : https://swieeft.github.io/2020/03/05/UIViewRoundCorners.html
     private let profileView: ProfileView = {
         let profileView = ProfileView()

--- a/Workade/Views&ViewModels/MyPage/ProfileView.swift
+++ b/Workade/Views&ViewModels/MyPage/ProfileView.swift
@@ -8,8 +8,6 @@
 import UIKit
 
 class ProfileView: UIView {
-    // TODO: Login User 정보 ViewModel 사용
-    
     let containerView: UIView = {
         let containerView = UIView()
         containerView.backgroundColor = .clear


### PR DESCRIPTION
# 배경
- 준비중인 지역에서 하단 뷰를 끄기위한 dismiss 버튼이 없어 UX 적으로 유저들이 불편해함

# 작업 내용
- 준비중인 지역에서 하단 뷰를 끄기위한 dismiss 버튼 노출 및 활성화
- 일부 주석 및 화이트 스페이스 제거로 SwiftLint 경고 수정

# 테스트 방법
- 실행 후 각 지역을 눌러 x 버튼이 작동하는지 확인

# 스크린샷
<img width="432" alt="image" src="https://user-images.githubusercontent.com/96639917/205591874-63e923c6-a505-4810-a7b5-d720c9ef88b7.png">
