### PR TITLE
✨ 유저의 스티커가 없을때 비어있는 뷰를 호출했습니다.

### DIFF
--- a/Workade.xcodeproj/project.pbxproj
+++ b/Workade.xcodeproj/project.pbxproj
@@ -53,7 +53,6 @@
 		2170C28F292BB0BC005146C3 /* ExploreViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170C28E292BB0BC005146C3 /* ExploreViewController.swift */; };
 		2170C291292C974B005146C3 /* ExploreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170C290292C974B005146C3 /* ExploreViewModel.swift */; };
 		2170C293292CA689005146C3 /* RegionInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2170C292292CA689005146C3 /* RegionInfoView.swift */; };
-		21723FB8293BA3800064255C /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 21723FB7293BA3800064255C /* GoogleService-Info.plist */; };
 		21862A912902675600518EBC /* GalleryDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21862A902902675500518EBC /* GalleryDetailViewController.swift */; };
 		21862A93290280BD00518EBC /* CardTransitionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21862A92290280BD00518EBC /* CardTransitionManager.swift */; };
 		218DA403290B1AA90089F896 /* LaunchScreenAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 218DA402290B1AA90089F896 /* LaunchScreenAnimationView.swift */; };
@@ -156,6 +155,7 @@
 		A35A982F290ADE1F00220755 /* MagazineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35A982E290ADE1F00220755 /* MagazineViewModel.swift */; };
 		A35B7096292CF6EE0083E0A2 /* RegionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35B7095292CF6EE0083E0A2 /* RegionButton.swift */; };
 		A35BD48228FE85B200D1FA7C /* MagazineViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */; };
+		A3690FAE293DEAFF004B79F2 /* EmptyStickeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3690FAD293DEAFF004B79F2 /* EmptyStickeView.swift */; };
 		A37D28402923BC8F009F0ED6 /* NearbyPlaceImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37D283F2923BC8F009F0ED6 /* NearbyPlaceImageView.swift */; };
 		A37D28422923BD53009F0ED6 /* NearbyPlaceDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37D28412923BD53009F0ED6 /* NearbyPlaceDetailView.swift */; };
 		A37D28442923C62E009F0ED6 /* GalleryResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = A37D28432923C62E009F0ED6 /* GalleryResource.swift */; };
@@ -218,7 +218,6 @@
 		2170C28E292BB0BC005146C3 /* ExploreViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewController.swift; sourceTree = "<group>"; };
 		2170C290292C974B005146C3 /* ExploreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExploreViewModel.swift; sourceTree = "<group>"; };
 		2170C292292CA689005146C3 /* RegionInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionInfoView.swift; sourceTree = "<group>"; };
-		21723FB7293BA3800064255C /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../Desktop/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		21862A902902675500518EBC /* GalleryDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryDetailViewController.swift; sourceTree = "<group>"; };
 		21862A92290280BD00518EBC /* CardTransitionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardTransitionManager.swift; sourceTree = "<group>"; };
 		218DA402290B1AA90089F896 /* LaunchScreenAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchScreenAnimationView.swift; sourceTree = "<group>"; };
@@ -316,6 +315,7 @@
 		A35A982E290ADE1F00220755 /* MagazineViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineViewModel.swift; sourceTree = "<group>"; };
 		A35B7095292CF6EE0083E0A2 /* RegionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegionButton.swift; sourceTree = "<group>"; };
 		A35BD48128FE85B200D1FA7C /* MagazineViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MagazineViewController.swift; sourceTree = "<group>"; };
+		A3690FAD293DEAFF004B79F2 /* EmptyStickeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStickeView.swift; sourceTree = "<group>"; };
 		A37D283F2923BC8F009F0ED6 /* NearbyPlaceImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyPlaceImageView.swift; sourceTree = "<group>"; };
 		A37D28412923BD53009F0ED6 /* NearbyPlaceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NearbyPlaceDetailView.swift; sourceTree = "<group>"; };
 		A37D28432923C62E009F0ED6 /* GalleryResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GalleryResource.swift; sourceTree = "<group>"; };
@@ -599,7 +599,6 @@
 			isa = PBXGroup;
 			children = (
 				5FDC17D228FE7A900060DBB7 /* .swiftlint.yml */,
-				21723FB7293BA3800064255C /* GoogleService-Info.plist */,
 				5FDC17B928FE799C0060DBB7 /* Workade */,
 				5FDC17B828FE799C0060DBB7 /* Products */,
 				B7DE360250B0A3F5EC254C91 /* Pods */,
@@ -740,6 +739,7 @@
 				A354F476292625F5003E601A /* ProfileView.swift */,
 				A354F47829262615003E601A /* StickerView.swift */,
 				A354F47A29263C52003E601A /* StickerCollectionViewCell.swift */,
+				A3690FAD293DEAFF004B79F2 /* EmptyStickeView.swift */,
 				A3BB02BB2926A7C8000DE275 /* EditProfile */,
 				9646763D2909346A0047ED34 /* Setting */,
 			);
@@ -925,7 +925,6 @@
 				5FDC17D328FE7A900060DBB7 /* .swiftlint.yml in Resources */,
 				21F6DE5D28FFED5D00ED72C6 /* Pretendard-Regular.otf in Resources */,
 				2103BBA929261F4D00BBCB2C /* Satoshi-Medium.otf in Resources */,
-				21723FB8293BA3800064255C /* GoogleService-Info.plist in Resources */,
 				21F6DE5E28FFED5D00ED72C6 /* Pretendard-Bold.otf in Resources */,
 				5FDC17CA28FE799D0060DBB7 /* LaunchScreen.storyboard in Resources */,
 				21F6DE5C28FFED5D00ED72C6 /* Pretendard-SemiBold.otf in Resources */,
@@ -1128,6 +1127,7 @@
 				5FDC17BB28FE799C0060DBB7 /* AppDelegate.swift in Sources */,
 				21DF04BC2907E9BE007B6270 /* EmojiPickerController.swift in Sources */,
 				A3CBB16629275F97009AD4E1 /* UITextField+.swift in Sources */,
+				A3690FAE293DEAFF004B79F2 /* EmptyStickeView.swift in Sources */,
 				A3479C96292BA84800AE1528 /* LoginInformationView.swift in Sources */,
 				A35A982F290ADE1F00220755 /* MagazineViewModel.swift in Sources */,
 				96B1836E290148D4009F2BC6 /* OfficeCollectionViewCell.swift in Sources */,

--- a/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
+++ b/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
@@ -18,10 +18,11 @@ class EmptyStickeView: UIView {
     
     private let emptyStickerLabel: UILabel = {
         let label = UILabel()
-        label.text = "각 지역별 워케이션을 통해 스티커를 획득하세요!"
+        label.text = "각 지역별 워케이션을 통해\n스티커를 획득하세요!"
         label.font = .customFont(for: .captionHeadline)
-        label.textColor = .theme.primary
-        label.numberOfLines = 1
+        label.textColor = .theme.tertiary
+        label.numberOfLines = 0
+        label.textAlignment = .center
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label

--- a/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
+++ b/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
@@ -8,13 +8,46 @@
 import UIKit
 
 class EmptyStickeView: UIView {
-
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    private let emptyStickerImageView: UIImageView = {
+        let imageView = UIImageView(image: UIImage(named: "blank"))
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
+        return imageView
+    }()
+    
+    private let emptyStickerLabel: UILabel = {
+        let label = UILabel()
+        label.text = "워케이션을 해서 스티커를 획득하세요!"
+        label.font = .customFont(for: .captionHeadline)
+        label.textColor = .theme.primary
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupLayout()
     }
-    */
-
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        addSubview(emptyStickerImageView)
+        NSLayoutConstraint.activate([
+            emptyStickerImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            emptyStickerImageView.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+        
+        addSubview(emptyStickerLabel)
+        NSLayoutConstraint.activate([
+            emptyStickerLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            emptyStickerLabel.topAnchor.constraint(equalTo: emptyStickerImageView.bottomAnchor, constant: 20)
+        ])
+    }
 }

--- a/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
+++ b/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
@@ -1,0 +1,20 @@
+//
+//  EmptyStickeView.swift
+//  Workade
+//
+//  Created by Hong jeongmin on 2022/12/05.
+//
+
+import UIKit
+
+class EmptyStickeView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
+++ b/Workade/Views&ViewModels/MyPage/EmptyStickeView.swift
@@ -18,7 +18,7 @@ class EmptyStickeView: UIView {
     
     private let emptyStickerLabel: UILabel = {
         let label = UILabel()
-        label.text = "워케이션을 해서 스티커를 획득하세요!"
+        label.text = "각 지역별 워케이션을 통해 스티커를 획득하세요!"
         label.font = .customFont(for: .captionHeadline)
         label.textColor = .theme.primary
         label.numberOfLines = 1

--- a/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
+++ b/Workade/Views&ViewModels/MyPage/MyPageViewController.swift
@@ -30,10 +30,21 @@ final class MyPageViewController: UIViewController {
         return stickerView
     }()
     
+    private let emptyStickerView: EmptyStickeView = {
+        let emptyStickerView = EmptyStickeView()
+        emptyStickerView.translatesAutoresizingMaskIntoConstraints = false
+        emptyStickerView.layer.cornerRadius = 30
+        emptyStickerView.layer.maskedCorners = CACornerMask(arrayLiteral: .layerMinXMinYCorner, .layerMaxXMinYCorner)
+        emptyStickerView.backgroundColor = .theme.background
+        
+        return emptyStickerView
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .theme.primary
         
+        setupStickerView()
         editProfileButtonTapped()
         setupNavigationBar()
         setupLayout()
@@ -59,6 +70,22 @@ final class MyPageViewController: UIViewController {
         profileView.jobLabel.text = user.job.rawValue
         
         // TODO: Combine이던, Binder던 콜렉션뷰 reload해야할것 같음
+    }
+    
+    func setupStickerView() {
+        guard let stickersArray = UserManager.shared.user.value?.stickers else {
+            emptyStickerView.isHidden = false
+            stickerView.isHidden = true
+            return
+        }
+        
+        if stickersArray.count == 0 {
+            emptyStickerView.isHidden = false
+            stickerView.isHidden = true
+        } else {
+            emptyStickerView.isHidden = true
+            stickerView.isHidden = false
+        }
     }
 }
 
@@ -100,6 +127,14 @@ private extension MyPageViewController {
             stickerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
             stickerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             stickerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+        ])
+        
+        view.addSubview(emptyStickerView)
+        NSLayoutConstraint.activate([
+            emptyStickerView.topAnchor.constraint(equalTo: profileView.bottomAnchor, constant: 4),
+            emptyStickerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            emptyStickerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            emptyStickerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
         ])
     }
 }


### PR DESCRIPTION
# 배경
- 유저의 스티커갯수가 없을때 텅 비어있는 화면을 보수

# 작업 내용
- EmptyStikerView 구현하여 스티커가 없을때 해당 뷰를 호출

# 테스트 방법
- 실행하여 스티커가 있을때, 없을때를 비교 판단 해주세요!

# 스크린샷
<img width="436" alt="image" src="https://user-images.githubusercontent.com/96639917/205600659-d7202430-b4ea-468d-bd17-84659ecd4453.png">