### PR TITLE
♻️  직업 라벨 색깔을 현재 직업에 따라 보이도록 변경했습니다.

### DIFF
--- a/Workade/Views&ViewModels/Workation/WorkerStatusSheet/WorkerStatusSheetViewController.swift
+++ b/Workade/Views&ViewModels/Workation/WorkerStatusSheet/WorkerStatusSheetViewController.swift
@@ -86,8 +86,8 @@ class WorkerStatusSheetViewController: UIViewController {
     
     private lazy var numberOfWorkersStack: UIStackView = {
         let firstStack = UIStackView(arrangedSubviews: [
-            jobLabel(job: Job.designer, number: 0, isMyJob: true),
-            jobLabel(job: Job.developer, number: 0, isMyJob: false)
+            jobLabel(job: Job.designer, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.designer),
+            jobLabel(job: Job.developer, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.developer)
         ])
         
         firstStack.axis = .horizontal
@@ -95,31 +95,31 @@ class WorkerStatusSheetViewController: UIViewController {
         firstStack.spacing = 30
         
         let secondStack = UIStackView(arrangedSubviews: [
-            jobLabel(job: Job.writer, number: 0, isMyJob: false),
-            jobLabel(job: Job.PM, number: 0, isMyJob: false)
+            jobLabel(job: Job.writer, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.writer),
+            jobLabel(job: Job.PM, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.PM)
         ])
         secondStack.axis = .horizontal
         secondStack.distribution = .fillEqually
         secondStack.spacing = 30
         
         let thirdStack = UIStackView(arrangedSubviews: [
-            jobLabel(job: Job.creater, number: 0, isMyJob: false),
-            jobLabel(job: Job.marketer, number: 0, isMyJob: false)
+            jobLabel(job: Job.creater, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.creater),
+            jobLabel(job: Job.marketer, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.marketer)
         ])
         thirdStack.axis = .horizontal
         thirdStack.distribution = .fillEqually
         thirdStack.spacing = 30
         
         let fourthStack = UIStackView(arrangedSubviews: [
-            jobLabel(job: Job.artist, number: 0, isMyJob: false),
-            jobLabel(job: Job.freelancer, number: 0, isMyJob: false)
+            jobLabel(job: Job.artist, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.artist),
+            jobLabel(job: Job.freelancer, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.freelancer)
         ])
         fourthStack.axis = .horizontal
         fourthStack.distribution = .fillEqually
         fourthStack.spacing = 30
         
         let fifthStack = UIStackView(arrangedSubviews: [
-            jobLabel(job: Job.etc, number: 0, isMyJob: false),
+            jobLabel(job: Job.etc, number: 0, isMyJob: UserManager.shared.activeMyInfo?.job == Job.etc),
             UIView()
         ])
         fifthStack.axis = .horizontal


### PR DESCRIPTION
# 배경
- "워케이션 하러가기" -> "누군지 알아보기"에서, 기존에 디자인에 하이라이팅 되어 있도록 코드가 작성되어 있었습니다.

# 작업 내용
- WorkerStatusSheetViewController에서, joblabel의 isMyJob에 기존에 true, false로만 설정되어 있었습니다.
- 내가 디자이너면 디자인, 개발자면 개발에 하이라이팅이 되어야하므로, activeMyInfo의 job과 일치하는가로 변경하였습니다.
- "나도 같이 동참하기" 버튼을 누르지 않으면 모든 라벨이 검은색입니다.

# 테스트 방법
- 작업 내용을 테스트 하는 방법

# 스크린샷
- 워케이션 참여중이지 않을때
<img width="300" alt="image" src="https://user-images.githubusercontent.com/75309495/206204001-30e7511e-2514-437c-89f5-bd48a1096ba1.png">
- 워케이션 참여중일 때
<img width="300" alt="image" src="https://user-images.githubusercontent.com/75309495/206204479-5a27c6af-8bff-482d-97e9-d14fadb0a63c.png">
