### PR TITLE
♻️  체크리스트에서 제목없음, 내용없음을 placeholder로 교체

### DIFF
--- a/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailCell/CheckListDetailCell.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailCell/CheckListDetailCell.swift
@@ -50,6 +50,7 @@ class CheckListDetailCell: UITableViewCell {
         checkButton.setImage(todo.done ? UIImage(systemName: "checkmark.circle.fill") : UIImage(systemName: "circle"), for: .normal)
         checkButton.tintColor = todo.done ? .theme.workadeBlue : .theme.primary
         contentText.text = todo.content
+        contentText.textColor = todo.content != Optional("내용없음") ? .theme.primary : .lightGray
     }
 }
 

--- a/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailViewController.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailViewController.swift
@@ -291,7 +291,8 @@ extension CheckListDetailViewController {
         
         NSLayoutConstraint.activate([
             titleLabel.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
-            titleLabel.topAnchor.constraint(equalTo: scrollView.topAnchor)
+            titleLabel.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor)
         ])
         
         NSLayoutConstraint.activate([

--- a/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailViewController.swift
+++ b/Workade/Views&ViewModels/CheckList/CheckListDetail/CheckListDetailViewController.swift
@@ -59,6 +59,7 @@ class CheckListDetailViewController: UIViewController {
     
     private lazy var titleLabel: UITextField = {
         let textField = UITextField()
+        textField.textColor = selectedCheckList?.title != Optional("제목없음") ? .theme.primary : .lightGray
         textField.text = selectedCheckList?.title ?? "제목없음"
         textField.font = .customFont(for: .title2)
         textField.tintColor = .theme.primary
@@ -367,11 +368,26 @@ extension CheckListDetailViewController: UITableViewDataSource {
 }
 
 extension CheckListDetailViewController: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        if textField == titleLabel {
+            if textField.textColor == .lightGray {
+                textField.text = ""
+                textField.textColor = .theme.primary
+            }
+        } else {
+            if textField.textColor == .lightGray {
+                textField.text = ""
+                textField.textColor = .theme.primary
+            }
+        }
+    }
+    
     func textFieldDidEndEditing(_ textField: UITextField) {
         if textField == titleLabel {
             guard let targetCheckList = selectedCheckList else { return }
             if textField.text == "" {
                 textField.text = "제목없음"
+                textField.textColor = .lightGray
             }
             targetCheckList.title = textField.text
             editCheckListPublisher?.send(targetCheckList)
@@ -379,6 +395,7 @@ extension CheckListDetailViewController: UITextFieldDelegate {
             let todo = checkListDetailViewModel.todos[textField.tag]
             if textField.text == "" {
                 textField.text = "내용없음"
+                textField.textColor = .lightGray
             }
             todo.content = textField.text
             checkListDetailViewModel.updateTodo(at: textField.tag, todo: todo)


### PR DESCRIPTION
# 배경
- 오늘 유저들이 사용하면서, 체크리스트 생성 후 제목 수정과 내용 수정에서 불편함을 호소했습니다.

# 작업 내용
- 최초 체크리스트 생성에서 제목없음 타이틀을 Placeholder로 교체했습니다. 제목 없음 상태에서 나갔다 들어오거나, 제목을 다 지운상태로 나갔다 들어오거나 했을때는 Placeholder로 제목없음이 나타납니다.
- tableView의 목록에서도 마찬가지로 구현했습니다. 
- placeholder는 UITextFieldDelegate의 textFieldDidBeginEditing 함수와 textFieldDidEndEditing을 활용해 구현하였습니다.

# 테스트 방법
- 체크리스트를 작성해 봅니다.

# 스크린샷
<img width="300" alt="image" src="https://user-images.githubusercontent.com/75309495/206246477-42f16f92-5b64-494e-984f-177a85fc8200.png">
