### PR TITLE
♻️ 필요없는 폰트 가이드라인을 제거했습니다

### DIFF
--- a/Workade/Extentions/UIFont+.swift
+++ b/Workade/Extentions/UIFont+.swift
@@ -36,10 +36,6 @@ extension UIFont {
             return UIFont(name: CustomFont.satoshiBold.rawValue, size: 12) ?? UIFont.systemFont(ofSize: 12, weight: .regular)
         case .tag:
             return UIFont(name: CustomFont.satoshiRegular.rawValue, size: 10) ?? UIFont.systemFont(ofSize: 10, weight: .regular)
-        case .captionHeadlineNew:
-            return UIFont(name: CustomFont.pretendardBold.rawValue, size: 17) ?? UIFont.systemFont(ofSize: 17, weight: .bold)
-            // TODO: Font 적용하기
-            // TODO: Font 정리는 일일이 하기보단, 추후 한번에 정리하는게 효율적일듯 합니다.
         }
     }
 }
@@ -69,5 +65,4 @@ enum CustomTextStyle: String {
     case caption
     case caption2
     case tag
-    case captionHeadlineNew
 }

--- a/Workade/Views&ViewModels/Login/LoginJob/LoginJobViewController.swift
+++ b/Workade/Views&ViewModels/Login/LoginJob/LoginJobViewController.swift
@@ -22,7 +22,7 @@ class LoginJobViewController: UIViewController {
             guideLable.text = "XXX님의 현재\n무슨 일을 하고 계신가요?"
         }
         guideLable.textColor = .black
-        guideLable.font = .customFont(for: .captionHeadlineNew)
+        guideLable.font = .customFont(for: .captionHeadline)
         guideLable.setLineHeight(lineHeight: 10)
         guideLable.textAlignment = .center
         

--- a/Workade/Views&ViewModels/Login/LoginName/LoginNameViewController.swift
+++ b/Workade/Views&ViewModels/Login/LoginName/LoginNameViewController.swift
@@ -12,7 +12,7 @@ final class LoginNameViewController: UIViewController, UITextFieldDelegate {
         let guideLabel = UILabel()
         guideLabel.translatesAutoresizingMaskIntoConstraints = false
         guideLabel.text = "안녕하세요\n이름이 뭔지 알려주세요!"
-        guideLabel.font = .customFont(for: .captionHeadlineNew)
+        guideLabel.font = .customFont(for: .captionHeadline)
         guideLabel.textColor = .black
         guideLabel.numberOfLines = 0
         guideLabel.setLineHeight(lineHeight: 10)

--- a/Workade/Views&ViewModels/Login/LoginView.swift
+++ b/Workade/Views&ViewModels/Login/LoginView.swift
@@ -13,7 +13,7 @@ class  LoginView: UIView {
         let guidance = UILabel()
         guidance.text = "워케이션을 즐기고\n다양한 스티커를 얻어보세요"
         guidance.setLineHeight(lineHeight: 10)
-        guidance.font = .customFont(for: .captionHeadlineNew)
+        guidance.font = .customFont(for: .captionHeadline)
         guidance.textAlignment = .center
         guidance.translatesAutoresizingMaskIntoConstraints = false
         guidance.numberOfLines = 0

--- a/Workade/Views&ViewModels/MyPage/Setting/LoginInformationView.swift
+++ b/Workade/Views&ViewModels/MyPage/Setting/LoginInformationView.swift
@@ -11,7 +11,7 @@ class LoginInformationView: UIView {
     private let loginInformationLabel: UILabel = {
         let loginInformationLabel = UILabel()
         loginInformationLabel.text = "로그인 정보"
-        loginInformationLabel.font = .customFont(for: .captionHeadlineNew)
+        loginInformationLabel.font = .customFont(for: .captionHeadline)
         loginInformationLabel.textColor = .theme.primary
         loginInformationLabel.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Workade/Views&ViewModels/MyPage/Setting/SettingViewController.swift
+++ b/Workade/Views&ViewModels/MyPage/Setting/SettingViewController.swift
@@ -28,7 +28,7 @@ final class SettingViewController: UIViewController {
     private let settingLabel: UILabel = {
         let label = UILabel()
         label.text = "설정"
-        label.font = .customFont(for: .captionHeadlineNew)
+        label.font = .customFont(for: .captionHeadline)
         label.textColor = .theme.primary
         label.translatesAutoresizingMaskIntoConstraints = false
         

--- a/Workade/Views&ViewModels/NearbyPlace/Map/MapInfoView.swift
+++ b/Workade/Views&ViewModels/NearbyPlace/Map/MapInfoView.swift
@@ -21,7 +21,7 @@ final class MapInfoView: UIView {
     private let titleLabel: UILabel = {
         let title = UILabel()
         title.translatesAutoresizingMaskIntoConstraints = false
-        title.font = .customFont(for: .captionHeadlineNew)
+        title.font = .customFont(for: .captionHeadline)
         title.textColor = .black
         
         return title

--- a/Workade/Views&ViewModels/Workation/StickerSheet/StickerSheetViewController.swift
+++ b/Workade/Views&ViewModels/Workation/StickerSheet/StickerSheetViewController.swift
@@ -37,7 +37,7 @@ class StickerSheetViewController: UIViewController {
     
     private let getStickerLabel: UILabel = {
         let label = UILabel()
-        label.font = .customFont(for: .captionHeadlineNew)
+        label.font = .customFont(for: .captionHeadline)
         label.textColor = .theme.background
         label.text = "새로운 스티커를 획득했어요!"
         label.translatesAutoresizingMaskIntoConstraints = false

--- a/Workade/Views&ViewModels/Workation/WorkationViewController.swift
+++ b/Workade/Views&ViewModels/Workation/WorkationViewController.swift
@@ -135,7 +135,7 @@ final class WorkationViewController: UIViewController {
     
     private let funnyWorkationLabel: UILabel = {
         let label = UILabel()
-        label.font = .customFont(for: .captionHeadlineNew)
+        label.font = .customFont(for: .captionHeadline)
         label.textColor = .theme.primary
         label.text = "즐거운 워케이션이네요!"
         

--- a/Workade/Views&ViewModels/Workation/WorkerStatusSheet/WorkerStatusSheetViewController.swift
+++ b/Workade/Views&ViewModels/Workation/WorkerStatusSheet/WorkerStatusSheetViewController.swift
@@ -51,7 +51,7 @@ class WorkerStatusSheetViewController: UIViewController {
     
     private let wholeWorkerLabel: UILabel = {
         let label = UILabel()
-        label.font = .customFont(for: .captionHeadlineNew)
+        label.font = .customFont(for: .captionHeadline)
         label.textColor = .theme.secondary
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping


### PR DESCRIPTION
# 배경
1차, 2차 스프린트 사이에서 추가되었던 captionHeadline을 임시로 코드로 사용하기 위해 들어있던 .captionHeadlineNew를 제거할 필요가 있었습니다.

# 작업 내용
- CustomTextStyle에서 captionHeadlineNew를 제거했습니다.
- 레거시된 가이드라인을 사용하는 뷰의 폰트를 수정했습니다.

# 테스트 방법
- 새로이 적용된 폰트가 활용된 뷰가 제대로 보이는 지 확인해주세요